### PR TITLE
Fix submit button

### DIFF
--- a/app/views/lit/sources/_form.html.erb
+++ b/app/views/lit/sources/_form.html.erb
@@ -30,6 +30,6 @@
   </div>
 
   <div class="actions">
-    <%= f.submit t('lit.common.save'), :class=>"btn" %>
+    <%= f.submit t('lit.common.save', :default => "Save"), :class=>"btn" %>
   </div>
 <% end %>


### PR DESCRIPTION
if there is no translation and no default message the '<span class="translation_missing"' is returned which brake html structure
