### PR TITLE
Optimization

### DIFF
--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -58,6 +58,12 @@ module Lit
       self.updated_at.to_s(:db)
     end
 
+    def update_default_value(value)
+      return true if persisted? && default_value == value
+      self.default_value = value
+      self.save!
+    end
+
     private
       def update_is_changed
         unless is_changed?

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -49,6 +49,13 @@ class LitBehaviourTest < ActiveSupport::TestCase
     assert_equal 'foo bar bis', I18n.t(:blank, :scope => :next_scope, :default => :foo, :bar => "bar bis")
   end
 
+  test "lit should respect :scope when setting default_value from defaults" do
+    I18n.backend.store_translations(:en, :'scope.foo' => 'translated foo')
+
+    assert_equal 'translated foo', I18n.t(:not_existing, :scope => ['scope'], :default => [:foo])
+    assert_equal "translated foo", find_localization_for('scope.not_existing', 'en').default_value
+  end
+
   private
 
   def find_localization_for(key, locale)


### PR DESCRIPTION
- save Localization record only when default_value is changed - ActiveRecord always save records(even when no changes are present) when one of columns is serialized
- save nil values in redis cache
- optimize deleting localizations - do not create localization only to immediately destroy it
- fix saving default_value from options[:default] in lookup method - normalize keys first because options[:scope] should be applied too
