### PR TITLE
Update pagination to bootstrap 3

### DIFF
--- a/app/views/kaminari/lit/_paginator.html.erb
+++ b/app/views/kaminari/lit/_paginator.html.erb
@@ -1,6 +1,6 @@
 <%= paginator.render do %>
-  <div class="pagination">
-    <ul>
+  <div>
+    <ul class="pagination">
       <%= first_page_tag unless current_page.first? %>
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| %>


### PR DESCRIPTION
_paginator.html.erb uses the old bootstrap 2 pagination format: http://getbootstrap.com/2.3.2/components.html#pagination

This commit updates the paginator to work with Bootstrap 3:
http://getbootstrap.com/components/#pagination
