### PR TITLE
fix for #2

### DIFF
--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -29,11 +29,9 @@ module Lit
     # @param [Hash] data nested key-value pairs to be added as blurbs
     def store_translations(locale, data, options = {})
       super
-      locales = ::Rails.configuration.i18n.available_locales.map(&:to_s)
-
-      if !locales || locales.include?(locale)
+      locales = ::Rails.configuration.i18n.available_locales
+      if !locales || locales.map(&:to_s).include?(locale.to_s)
         store_item(locale, data)
-      else
       end
     end
 

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -40,6 +40,17 @@ class LitBehaviourTest < ActiveSupport::TestCase
     end
   end
 
+  test "should not save in other languages then I18n.available_locales" do
+    ::Rails.configuration.i18n.stubs(:available_locales).returns([:fr])
+    I18n.backend.expects(:store_item).times(0)
+    I18n.backend.store_translations(:dk, :'foo' => 'foo')
+  end
+
+  test "should save in other languages if I18n.available_locales is empty" do
+    I18n.backend.expects(:store_item).times(1)
+    I18n.backend.store_translations(:dk, :'foo' => 'foo')
+  end
+
   test "translating the same not existing key twice should not set Lit::Localizaiton#is_changed to true" do
     key = 'not_existing_translation'
 


### PR DESCRIPTION
Changed the backend to only store items in the `available_locales` languages. (as requested in #2)
