### PR TITLE
Fix parent_prefix navigation in sidebar

### DIFF
--- a/app/views/lit/localization_keys/index.html.erb
+++ b/app/views/lit/localization_keys/index.html.erb
@@ -88,7 +88,7 @@
       <li class="nav-header">Narrow with prefix</li>
       <% if @search_options[:key_prefix].present? %>
         <li>
-          <%= link_to url_for(@search_options.merge(:key_prefix=>p)), :title=>(@parent_prefix.present? ? @parent_prefix : 'show all') do %>
+          <%= link_to url_for(@search_options.merge(:key_prefix=>@parent_prefix.present? ? @parent_prefix : nil)), :title=>(@parent_prefix.present? ? @parent_prefix : 'show all') do %>
             <%= draw_icon('chevron-left') %>
             <%= @parent_prefix.present? ? @parent_prefix.split('.').last : 'show all' %>
           <% end %>


### PR DESCRIPTION
The `key_prefix` parameter wasn't correctly set for parent entry in sidebar resulting in always redirect to show all keys instead of parent.