### PR TITLE
Handle serialized attributes better in synchronize

### DIFF
--- a/app/models/lit/source.rb
+++ b/app/models/lit/source.rb
@@ -47,8 +47,8 @@ module Lit
             il.localization_key = LocalizationKey.where(localization_key: il.localization_key_str).first
             unless il.is_duplicate?(r['value'])
               il.save!
-              IncommingLocalization.where(id: il.id).
-                update_all ['translated_value=?', r['value']]
+              IncommingLocalization.where(id: il.id).first.
+                update_attributes(translated_value: r['value'])
             end
           end
           last_change = get_last_change


### PR DESCRIPTION
Previously: The underlying SQL looks something like this: `UPDATE "lit_incomming_localizations" SET translated_value='Sun','Mon','Tue','Wed','Thu','Fri','Sat' WHERE "lit_incomming_localizations"."id" = $1`, which is invalid SQL.

Now: It serializes the array before trying to insert it.