### PR TITLE
Consider only UI-made changes in synchronization API (without schema modification)

### DIFF
--- a/app/controllers/lit/api/v1/localization_keys_controller.rb
+++ b/app/controllers/lit/api/v1/localization_keys_controller.rb
@@ -9,7 +9,6 @@ module Lit
       else
         @localization_keys = @localization_keys.all
       end
-      puts @localization_keys.count
       render json: @localization_keys.as_json(root: false, only: [:id, :localization_key])
     end
   end

--- a/app/controllers/lit/api/v1/localization_keys_controller.rb
+++ b/app/controllers/lit/api/v1/localization_keys_controller.rb
@@ -9,6 +9,7 @@ module Lit
       else
         @localization_keys = @localization_keys.all
       end
+      puts @localization_keys.count
       render json: @localization_keys.as_json(root: false, only: [:id, :localization_key])
     end
   end

--- a/app/controllers/lit/localizations_controller.rb
+++ b/app/controllers/lit/localizations_controller.rb
@@ -10,6 +10,7 @@ module Lit
 
     def update
       if @localization.update_attributes(clear_params)
+        @localization.update_column :is_changed, true
         Lit.init.cache.update_cache @localization.full_key, @localization.get_value
       end
       @localization.reload

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -28,7 +28,7 @@ module Lit
 
     ## BEFORE & AFTER
     with_options if: :translated_value_changed? do |o|
-      o.before_update :update_is_changed_attribute
+      o.before_update :update_should_mark_localization_key_completed
       o.before_update :create_version
     end
     after_update :mark_localization_key_completed
@@ -69,11 +69,8 @@ module Lit
 
     private
 
-    def update_is_changed_attribute
-      return if attributes['is_changed'] == true ||
-                translated_value == translated_value_was
-
-      self[:is_changed] = true
+    def update_should_mark_localization_key_completed
+      return if translated_value == translated_value_was
       @should_mark_localization_key_completed = true
     end
 

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -6,7 +6,10 @@ module Lit
     ## SCOPES
     scope :changed, proc { where(is_changed: true) }
     # @HACK: dirty, find a way to round date to full second
-    scope :after, proc { |dt| where('updated_at >= ?', dt + 1.second) }
+    scope :after, proc { |dt|
+      where('updated_at >= ?', dt + 1.second)
+        .where('is_changed = true')
+    }
 
     ## ASSOCIATIONS
     belongs_to :locale
@@ -67,7 +70,8 @@ module Lit
     private
 
     def update_is_changed_attribute
-      return if attributes['is_changed'] == true
+      return if attributes['is_changed'] == true ||
+                translated_value == translated_value_was
 
       self[:is_changed] = true
       @should_mark_localization_key_completed = true

--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -7,7 +7,11 @@ module Lit
     scope :not_completed, proc { where(is_completed: false) }
     scope :starred, proc { where(is_starred: true) }
     scope :ordered, proc { order('localization_key asc') }
-    scope :after, proc { |dt| where('updated_at >= ?', dt) }
+    scope :after, proc { |dt|
+      joins(:localizations)
+        .where('lit_localization_keys.updated_at >= ?', dt)
+        .where('lit_localizations.is_changed = true')
+    }
 
     ## ASSOCIATIONS
     has_many :localizations, dependent: :destroy

--- a/test/functional/lit/api/v1/localization_keys_controller_test.rb
+++ b/test/functional/lit/api/v1/localization_keys_controller_test.rb
@@ -18,8 +18,10 @@ module Lit
     test 'should only changed records' do
       I18n.l(Time.now)
       Lit::LocalizationKey.update_all ['updated_at=?', 2.hours.ago]
+      Lit::Localization.update_all ['updated_at=?', 2.hours.ago]
       l = Lit::LocalizationKey.last
       l.touch
+      l.localizations.each { |loc| loc.update(translated_value: 'trollolollo') }
       get :index, format: :json, after: I18n.l(2.seconds.ago)
       assert_response :success
       assert_equal 1, assigns(:localization_keys).count

--- a/test/functional/lit/api/v1/localization_keys_controller_test.rb
+++ b/test/functional/lit/api/v1/localization_keys_controller_test.rb
@@ -21,7 +21,9 @@ module Lit
       Lit::Localization.update_all ['updated_at=?', 2.hours.ago]
       l = Lit::LocalizationKey.last
       l.touch
-      l.localizations.each { |loc| loc.update(translated_value: 'trollolollo') }
+      l.localizations.each do |loc|
+        loc.update_column :is_changed, true
+      end
       get :index, format: :json, after: I18n.l(2.seconds.ago)
       assert_response :success
       assert_equal 1, assigns(:localization_keys).count

--- a/test/functional/lit/api/v1/localizations_controller_test.rb
+++ b/test/functional/lit/api/v1/localizations_controller_test.rb
@@ -20,6 +20,7 @@ module Lit
       Lit::Localization.update_all ['updated_at=?', 2.hours.ago]
       l = Lit::Localization.last
       l.translated_value = 'test'
+      l.is_changed = true
       l.save
       get :index, format: :json, after: 2.seconds.ago.to_s(:db)
       assert_response :success

--- a/test/functional/lit/localizations_controller_test.rb
+++ b/test/functional/lit/localizations_controller_test.rb
@@ -44,5 +44,17 @@ module Lit
       @localization.reload
       assert_equal %w(three two one), @localization.translated_value
     end
+
+    test 'should set is_changed to true' do
+      @localization = lit_localizations(:string)
+      assert_equal false, @localization.is_changed?
+      put :update, localization_key_id: @localization.localization_key.id,
+                   id: @localization.id, localization:
+                     { translated_value: 'new-value',
+                       locale_id: @localization.locale_id }, format: :js
+      assert_response :success
+      @localization.reload
+      assert_equal true, @localization.is_changed?
+    end
   end
 end

--- a/test/integration/lit/welcome_test.rb
+++ b/test/integration/lit/welcome_test.rb
@@ -75,8 +75,10 @@ class WelcomeTest < ActionDispatch::IntegrationTest
     text = 'Żegnaj okrutny świecie'
     localization.translated_value = text
     localization.save!
+    localization.update_column :is_changed, true
     Lit.init.cache.refresh_key(localization.full_key)
     visit('/pl/welcome')
+    localization.reload
     assert page.has_content?(text)
   end
 

--- a/test/unit/lit/incomming_localization_test.rb
+++ b/test/unit/lit/incomming_localization_test.rb
@@ -30,6 +30,7 @@ module Lit
       assert_equal 1, Locale.count
       assert_equal 1, Localization.count
       assert_equal 1, LocalizationKey.count
+      assert_equal true, Localization.first.is_changed?
     end
   end
 end

--- a/test/unit/lit/localization_test.rb
+++ b/test/unit/lit/localization_test.rb
@@ -23,11 +23,21 @@ module Lit
         l.reload
         l.translated_value = 'test'
         l.save!
+        l.update_attribute :is_changed, true
         l.reload
         assert_equal true, l.is_changed?
       end
       Lit.init.cache.reset
       assert_equal 'test', I18n.t('scope.text_with_translation_in_english')
+    end
+
+    test 'does not set is_changed to true upon update via model' do
+      I18n.locale = :en
+      assert_equal 'English translation', I18n.t('scope.text_with_translation_in_english')
+      l = Lit::Localization.first
+      assert_equal false, l.is_changed?
+      l.update_attributes(translated_value: 'Test')
+      assert_equal false, l.is_changed?
     end
   end
 end


### PR DESCRIPTION
From my analysis of the code and the way that `is_changed` is updated, this is enough. `before_update` callback on `localization` is obviously only called when the record is updated, not on creation, and the callback sets `is_changed` only if the translated value actually changed.

This way, `after` on `Localization` takes only translations marked as `is_changed` and `after` on `LocalizationKey` takes only keys that have a `Localization` marked as `is_changed`.

It all should work as we expect under the easy assumption that if we `accept` any incoming localization at server X, it should also be marked as `is_changed` included in a later synchronization from server X (which I believe is the intended behaviour).