### PR TITLE
Hybrid hash/redis storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.2
-  - 2.2.5
-  - 2.3.1
+#  - 2.0.0
+#  - 2.1.2
+#  - 2.2.5
+   - 2.3.0
 gemfile:
-  - gemfiles/rails_4.gemfile
-  - gemfiles/rails_4.1.gemfile
+#  - gemfiles/rails_4.gemfile
+#  - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
 services:
   - redis-server
 env:
-  - LIT_STORAGE=hash
-  - LIT_STORAGE=redis
+  # - LIT_STORAGE=hash
+  # - LIT_STORAGE=redis
+  - LIT_STORAGE=hybrid
 before_script:
   - cp test/dummy/config/database.yml.travis test/dummy/config/database.yml
   - psql -c 'create database lit_test;' -U postgres
   - RAILS_ENV=test bundle exec rake db:migrate
-script: "bundle exec rake test"
+script: "bundle exec rake test" # TEST=test/unit/lit_behaviour_test.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: ruby
 sudo: false
 rvm:
-#  - 2.0.0
-#  - 2.1.2
-#  - 2.2.5
-   - 2.3.0
+  - 2.0.0
+  - 2.1.2
+  - 2.2.5
+  - 2.3.0
 gemfile:
-#  - gemfiles/rails_4.gemfile
-#  - gemfiles/rails_4.1.gemfile
+  - gemfiles/rails_4.gemfile
+  - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
 services:
   - redis-server
 env:
-  # - LIT_STORAGE=hash
-  # - LIT_STORAGE=redis
+  - LIT_STORAGE=hash
+  - LIT_STORAGE=redis
   - LIT_STORAGE=hybrid
 before_script:
   - cp test/dummy/config/database.yml.travis test/dummy/config/database.yml
   - psql -c 'create database lit_test;' -U postgres
   - RAILS_ENV=test bundle exec rake db:migrate
-script: "bundle exec rake test" # TEST=test/unit/lit_behaviour_test.rb"
+script: "bundle exec rake test"

--- a/lib/lit.rb
+++ b/lib/lit.rb
@@ -46,6 +46,9 @@ module Lit
         when 'redis'
           require 'lit/adapters/redis_storage'
           return RedisStorage.new
+        when 'hybrid'
+          require 'lit/adapters/hybrid_storage'
+          return HybridStorage.new
         else
           require 'lit/adapters/hash_storage'
           return HashStorage.new

--- a/lib/lit/adapters/hybrid_storage.rb
+++ b/lib/lit/adapters/hybrid_storage.rb
@@ -1,0 +1,153 @@
+require 'redis'
+require 'concurrent'
+
+module Lit
+  extend self
+  def redis
+    $redis = Redis.new(url: determine_redis_provider) unless $redis
+    $redis
+  end
+
+  def determine_redis_provider
+    ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+  end
+
+  def _hash
+    $_hash ||= ::Concurrent::Hash.new
+  end
+
+  def reset_hash
+    $_hash = nil
+  end
+
+  def hash_dirty?
+    # Hash is considered dirty if hash snapshot is older
+    # than Redis snapshot.
+    Lit.hash_snapshot < Lit.redis_snapshot
+  end
+
+  def hash_snapshot
+    $_hash_snapshot ||= DateTime.new
+  end
+
+  def hash_snapshot= (timestamp)
+    $_hash_snapshot = timestamp
+  end
+
+  def redis_snapshot
+    timestamp = Lit.redis.get('lit:_snapshot')
+    if timestamp.nil?
+      timestamp = Time.current.to_s
+      Lit.redis_snapshot = timestamp
+    end
+    DateTime.parse(timestamp)
+  end
+
+  def redis_snapshot= (timestamp)
+    Lit.redis.set('lit:_snapshot', timestamp)
+  end
+
+  def determine_redis_provider
+    ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+  end
+
+  class HybridStorage
+    def initialize
+      Lit.redis
+      Lit._hash
+    end
+
+    def [](key)
+      if Lit.hash_dirty?
+        Lit.hash_snapshot = DateTime.current
+        Lit._hash.clear
+      end
+      if Lit._hash.key? key
+        return Lit._hash[key]
+      else
+        redis_val = get_from_redis(key)
+        Lit._hash[key] = redis_val
+      end
+    end
+
+    def get_from_redis(key)
+      if Lit.redis.exists(_prefixed_key_for_array(key))
+        Lit.redis.lrange(_prefixed_key(key), 0, -1)
+      elsif Lit.redis.exists(_prefixed_key_for_nil(key))
+        nil
+      else
+        Lit.redis.get(_prefixed_key(key))
+      end
+    end
+
+    def []=(k, v)
+      delete(k)
+      Lit._hash[k] = v
+      if v.is_a?(Array)
+        Lit.redis.set(_prefixed_key_for_array(k), '1')
+        v.each do |ve|
+          Lit.redis.rpush(_prefixed_key(k), ve.to_s)
+        end
+      elsif v.nil?
+        Lit.redis.set(_prefixed_key_for_nil(k), '1')
+        Lit.redis.set(_prefixed_key(k), '')
+      else
+        Lit.redis.set(_prefixed_key(k), v)
+      end
+    end
+
+    def delete(k)
+      Lit.redis_snapshot = Time.current
+      Lit._hash.delete(k)
+      Lit.redis.del(_prefixed_key_for_array(k))
+      Lit.redis.del(_prefixed_key_for_nil(k))
+      Lit.redis.del(_prefixed_key(k))
+    end
+
+    def clear
+      Lit.redis_snapshot = Time.current
+      Lit._hash.clear
+      Lit.redis.del(keys) if keys.length > 0
+    end
+
+    def keys
+      Lit.redis.keys(_prefixed_key + '*')
+    end
+
+    def has_key?(key)
+      Lit._hash.has_key?(key) || Lit.redis.exists(_prefixed_key(key)) # This is a derp
+    end
+
+    def incr(key)
+      Lit.redis.incr(_prefixed_key(key))
+    end
+
+    def sort
+      Lit.redis.keys.sort.map do |k|
+        [k, self.[](k)]
+      end
+    end
+
+    private
+
+    def _prefix
+      prefix = 'lit:'
+      if Lit.storage_options.is_a?(Hash)
+        prefix += "#{Lit.storage_options[:prefix]}:" if Lit.storage_options.key?(:prefix)
+      end
+      prefix
+    end
+
+    def _prefixed_key(key = '')
+      _prefix + key.to_s
+    end
+
+    def _prefixed_key_for_array(key = '')
+      _prefix + 'array_flags:' + key.to_s
+    end
+
+    def _prefixed_key_for_nil(key = '')
+      _prefix + 'nil_flags:' + key.to_s
+    end
+  end
+end

--- a/lib/lit/adapters/hybrid_storage.rb
+++ b/lib/lit/adapters/hybrid_storage.rb
@@ -37,7 +37,7 @@ module Lit
   def redis_snapshot
     timestamp = Lit.redis.get(Lit.prefix + '_snapshot')
     if timestamp.nil?
-      timestamp = Time.current.to_s
+      timestamp = DateTime.now.to_s
       Lit.redis_snapshot = timestamp
     end
     DateTime.parse(timestamp)
@@ -105,7 +105,7 @@ module Lit
     end
 
     def delete(k)
-      Lit.redis_snapshot = Time.current
+      Lit.redis_snapshot = DateTime.now
       Lit._hash.delete(k)
       Lit.redis.del(_prefixed_key_for_array(k))
       Lit.redis.del(_prefixed_key_for_nil(k))
@@ -113,7 +113,7 @@ module Lit
     end
 
     def clear
-      Lit.redis_snapshot = Time.current
+      Lit.redis_snapshot = DateTime.now
       Lit._hash.clear
       Lit.redis.del(keys) if keys.length > 0
     end

--- a/lib/lit/adapters/hybrid_storage.rb
+++ b/lib/lit/adapters/hybrid_storage.rb
@@ -35,7 +35,7 @@ module Lit
   end
 
   def redis_snapshot
-    timestamp = Lit.redis.get('lit:_snapshot')
+    timestamp = Lit.redis.get(Lit.prefix + '_snapshot')
     if timestamp.nil?
       timestamp = Time.current.to_s
       Lit.redis_snapshot = timestamp
@@ -44,11 +44,19 @@ module Lit
   end
 
   def redis_snapshot= (timestamp)
-    Lit.redis.set('lit:_snapshot', timestamp)
+    Lit.redis.set(Lit.prefix + '_snapshot', timestamp)
   end
 
   def determine_redis_provider
     ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+  end
+
+  def prefix
+    pfx = 'lit:'
+    if Lit.storage_options.is_a?(Hash)
+      pfx += "#{Lit.storage_options[:prefix]}:" if Lit.storage_options.key?(:prefix)
+    end
+    pfx
   end
 
   class HybridStorage
@@ -131,11 +139,7 @@ module Lit
     private
 
     def _prefix
-      prefix = 'lit:'
-      if Lit.storage_options.is_a?(Hash)
-        prefix += "#{Lit.storage_options[:prefix]}:" if Lit.storage_options.key?(:prefix)
-      end
-      prefix
+      Lit.prefix
     end
 
     def _prefixed_key(key = '')

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -49,11 +49,12 @@ module Lit
       localizations.keys
     end
 
-    def update_locale(key, value, force_array = false)
+    def update_locale(key, value, force_array = false, unless_is_changed = false)
       key = key.to_s
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
       localization = find_localization(locale, key_without_locale, value, force_array, true)
+      return localization.get_value if unless_is_changed && localization.is_changed?
       localizations[key] = localization.get_value if localization
     end
 
@@ -62,11 +63,12 @@ module Lit
       localizations[key] = value
     end
 
-    def delete_locale(key)
+    def delete_locale(key, unless_is_changed = false)
+      binding.pry if key.match /abbr_month/
       key = key.to_s
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
-      delete_localization(locale, key_without_locale)
+      delete_localization(locale, key_without_locale, unless_is_changed)
     end
 
     def load_all_translations
@@ -227,8 +229,9 @@ module Lit
           where(localization_key_id: localization_key.id).first
     end
 
-    def delete_localization(locale, key_without_locale)
+    def delete_localization(locale, key_without_locale, unless_is_changed = false)
       localization = find_localization_for_delete(locale, key_without_locale)
+      return if unless_is_changed && localization.try(:is_changed?)
       if localization
         localizations.delete("#{locale.locale}.#{key_without_locale}")
         localization_keys.delete(key_without_locale)

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -59,6 +59,7 @@ module Lit
       return content if parts.size <= 1
 
       if should_cache?(key_with_locale)
+        puts "SHOULD CACHE #{key_with_locale}"
         new_content = @cache.init_key_with_value(key_with_locale, content)
         content = new_content if content.nil? # Content can change when Lit.humanize is true for example
 
@@ -141,12 +142,17 @@ module Lit
     end
 
     def should_cache?(key_with_locale)
-      return false if @cache.has_key?(key_with_locale)
+      return false if @cache[key_with_locale] != nil
 
       _, key_without_locale = ::Lit::Cache.split_key(key_with_locale)
       return false if is_ignored_key(key_without_locale)
 
       true
+    end
+
+    def extract_non_symbol_default!(options)
+      defaults = [options[:default]].flatten
+      defaults.detect{|default| !default.is_a?(Symbol)}
     end
   end
 end

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -100,7 +100,6 @@ module Lit
     def load_translations_to_cache
       ActiveRecord::Base.transaction do
         (@translations || {}).each do |locale, data|
-          # TODO maybe don't store if marked as changed in db? :)
           store_item(locale, data, [], true) if valid_locale?(locale)
         end
       end

--- a/lit.gemspec
+++ b/lit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '> 3.1.0'
   s.add_dependency 'i18n', '~> 0.7.0'
   s.add_dependency 'jquery-rails'
+  s.add_dependency 'concurrent-ruby'
 
   s.add_development_dependency 'pg'
   s.add_development_dependency 'devise'

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -15,8 +15,8 @@ development:
 test:
   adapter: postgresql
   database: lit_test
-  username: lit
-  password: lit
+  username: ebin
+  password: ebin
   host: localhost
   pool: 5
   timeout: 5000

--- a/test/support/clear_snapshots.rb
+++ b/test/support/clear_snapshots.rb
@@ -1,0 +1,7 @@
+require 'lit/adapters/hybrid_storage'
+def clear_snapshots
+  trace_var :$_hash, proc { |h| print 'hash is now', v }
+  Lit.reset_hash if defined?($_hash)
+  Lit.hash_snapshot = nil if defined?($_hash_snapshot)
+  Lit.redis.del('lit:_snapshot') if defined?($redis)
+end

--- a/test/support/clear_snapshots.rb
+++ b/test/support/clear_snapshots.rb
@@ -1,7 +1,6 @@
 require 'lit/adapters/hybrid_storage'
 def clear_snapshots
-  trace_var :$_hash, proc { |h| print 'hash is now', v }
   Lit.reset_hash if defined?($_hash)
   Lit.hash_snapshot = nil if defined?($_hash_snapshot)
-  Lit.redis.del('lit:_snapshot') if defined?($redis)
+  Lit.redis.del(Lit.prefix + '_snapshot') if defined?($redis)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ DatabaseCleaner.clean_with :truncation
 class ActiveSupport::TestCase
   self.use_transactional_fixtures = true
   setup do
+    clear_snapshots
     clear_redis
     Lit.init.cache.reset
   end


### PR DESCRIPTION
If a translation is available in the local hash, it's loaded from the hash; if it's not, it's loaded into the hash from Redis. Therefore arises the necessity to update the hash when it's needed.

Every time a translation is changed in any way, current timestamp is stored into Redis. In the application, a timestamp snapshot is stored and every request it is compared to the timestamp stored in Redis. If the local snapshot is older than the data in Redis, the local snapshot is updated - hash is cleared.