### PR TITLE
Fix/yaml translations overwriting

### DIFF
--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -49,11 +49,12 @@ module Lit
       localizations.keys
     end
 
-    def update_locale(key, value, force_array = false)
+    def update_locale(key, value, force_array = false, unless_changed = false)
       key = key.to_s
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
       localization = find_localization(locale, key_without_locale, value, force_array, true)
+      return localization.get_value if unless_changed && localization.is_changed?
       localizations[key] = localization.get_value if localization
     end
 
@@ -62,11 +63,11 @@ module Lit
       localizations[key] = value
     end
 
-    def delete_locale(key)
+    def delete_locale(key, unless_changed = false)
       key = key.to_s
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
-      delete_localization(locale, key_without_locale)
+      delete_localization(locale, key_without_locale, unless_changed)
     end
 
     def load_all_translations
@@ -227,8 +228,9 @@ module Lit
           where(localization_key_id: localization_key.id).first
     end
 
-    def delete_localization(locale, key_without_locale)
+    def delete_localization(locale, key_without_locale, unless_changed = false)
       localization = find_localization_for_delete(locale, key_without_locale)
+      return if unless_changed && localization.try(:is_changed?)
       if localization
         localizations.delete("#{locale.locale}.#{key_without_locale}")
         localization_keys.delete(key_without_locale)

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -83,26 +83,26 @@ module Lit
       content
     end
 
-    def store_item(locale, data, scope = [])
+    def store_item(locale, data, scope = [], unless_changed = false)
       if data.respond_to?(:to_hash)
         # ActiveRecord::Base.transaction do
           data.to_hash.each do |key, value|
-            store_item(locale, value, scope + [key])
+            store_item(locale, value, scope + [key], unless_changed)
           end
         # end
       elsif data.respond_to?(:to_str)
         key = ([locale] + scope).join('.')
-        @cache[key] ||= data
+        @cache.update_locale(key, data, false, unless_changed)
       elsif data.nil?
         key = ([locale] + scope).join('.')
-        @cache.delete_locale(key)
+        @cache.delete_locale(key, unless_changed)
       end
     end
 
     def load_translations_to_cache
       ActiveRecord::Base.transaction do
         (@translations || {}).each do |locale, data|
-          store_item(locale, data) if valid_locale?(locale)
+          store_item(locale, data, [], true) if valid_locale?(locale)
         end
       end
     end

--- a/test/support/en.yml
+++ b/test/support/en.yml
@@ -1,0 +1,3 @@
+en:
+  foo: bar
+  nil_thing:

--- a/test/support/en_changed.yml
+++ b/test/support/en_changed.yml
@@ -1,0 +1,3 @@
+en:
+  foo: barbar
+  nil_thing: not nil anymore

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,11 @@ Rails.backtrace_cleaner.remove_silencers!
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
+# Helper for adding sample .yml file to load path
+def load_sample_yml(fname)
+  I18n.load_path << "#{File.dirname(__FILE__)}/support/#{fname}"
+end
+
 ActiveSupport::TestCase.fixture_path = File.expand_path('../fixtures', __FILE__)
 
 ## do not enforce available locales


### PR DESCRIPTION
The issue was:
1) User has a translation key specified in yml file (be it a nil value or not)
2) User translates it in Lit panel
3) Upon Lit restart, the translation is reset to value from yml file.
Resetting values to those from yml files is OK if the localization hasn't been touched in the Lit panel, but if the user has changed it in the panel, it's wrong behaviour - which has been described as "disappearing translations" by users.

In this PR, during Lit initialization, in the course of storing values from yml file into the cache, Lit does not store a localization if it has (in the meantime) been modified in user panel.