### PR TITLE
Rails 5 compatibility issue with url_for helper

### DIFF
--- a/app/views/lit/localization_keys/index.html.erb
+++ b/app/views/lit/localization_keys/index.html.erb
@@ -80,7 +80,7 @@
       <li class="nav-header"><%= t(".order_by", :default => "Order by") %>:</li>
       <% Lit::LocalizationKey.order_options.each do |order| %>
         <li class="<%= "active" if order == @search_options[:order]  %>">
-          <%= link_to url_for(@search_options.merge(:order => order)) do %>
+          <%= link_to url_for(@search_options.merge(:order => order).permit!) do %>
             <%= t("lit.order_options.#{order.gsub(" ", "_")}", :default => order.humanize) %>
           <% end %>
         </li>
@@ -88,7 +88,7 @@
       <li class="nav-header">Narrow with prefix</li>
       <% if @search_options[:key_prefix].present? %>
         <li>
-          <%= link_to url_for(@search_options.merge(:key_prefix=>@parent_prefix.present? ? @parent_prefix : nil)), :title=>(@parent_prefix.present? ? @parent_prefix : 'show all') do %>
+          <%= link_to url_for(@search_options.merge(:key_prefix=>@parent_prefix.present? ? @parent_prefix : nil).permit!), :title=>(@parent_prefix.present? ? @parent_prefix : 'show all') do %>
             <%= draw_icon('chevron-left') %>
             <%= @parent_prefix.present? ? @parent_prefix.split('.').last : 'show all' %>
           <% end %>
@@ -96,7 +96,7 @@
       <% end %>
       <% @prefixes.each do |p| %>
         <li class="key_prefix">
-        <%= link_to url_for(@search_options.merge(:key_prefix=>p)) do %>
+        <%= link_to url_for(@search_options.merge(:key_prefix=>p).permit!) do %>
           <%= draw_icon('chevron-right') %>
           <%=  p.split('.').last %>
         <% end %>


### PR DESCRIPTION
The current master doesn't work with Rails 5. An error is thrown in `app/views/lit/localization_keys/index.html.erb:81`:

> Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.

The url_for method expects now sanitized request parameters. I simply added a "permit!" to the code. This is a quick fix and is working for me now, but I think there is a better solution for it. (Unfortunatelly I don't have currently the time to investigate this completly...)
