### PR TITLE
fix: keys with array values are not being imported

### DIFF
--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -90,12 +90,16 @@ module Lit
             store_item(locale, value, scope + [key], unless_changed)
           end
         # end
-      elsif data.respond_to?(:to_str)
+      else
         key = ([locale] + scope).join('.')
-        @cache.update_locale(key, data, false, unless_changed)
-      elsif data.nil?
-        key = ([locale] + scope).join('.')
-        @cache.delete_locale(key, unless_changed)
+        if data.respond_to?(:to_str)
+          @cache.update_locale(key, data, false, unless_changed)
+        elsif data.is_a?(Array)
+          @cache.update_locale(key, data, true, unless_changed)
+        elsif data.nil?
+          key = ([locale] + scope).join('.')
+          @cache.delete_locale(key, unless_changed)
+        end
       end
     end
 


### PR DESCRIPTION
I found these value were not being imported into the DB:

  date:
    abbr_day_names:
    - Sun
    - Mon
    - Tue
    - Wed
    - Thu
    - Fri
    - Sat
    abbr_month_names:
    -
    - Jan
    - Feb
    - Mar
    - Apr
    - May
    - Jun
    - Jul
    - Aug
    - Sep
    - Oct
    - Nov
    - Dec
    day_names:
    - Sunday
    - Monday
    - Tuesday
    - Wednesday
    - Thursday
    - Friday
    - Saturday
    month_names:
    -
    - January
    - February
    - March
    - April
    - May
    - June
    - July
    - August
    - September
    - October
    - November
    - December
    order:
    - :year
    - :month
    - :day

This commit fixes that.