### PR TITLE
sanitize localization keys controller's params for filter and sorting

### DIFF
--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -35,7 +35,7 @@ module Lit
     private
 
     def get_localization_scope
-      @search_options = params.slice(*valid_keys)
+      @search_options = params.permit(valid_keys)
       @search_options[:include_completed] = '1' if @search_options.empty?
       @scope = LocalizationKey.uniq.preload(localizations: :locale).search(@search_options)
     end


### PR DESCRIPTION
From Rails 5, ActionController::Parameters is not a hash anymore, so #slice doesn’t work, and without sanitized parameters, we get:

Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.
