### PR TITLE
Ensure options[:default] works fine, ensure humanize_key is performed…

### DIFF
--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -42,7 +42,7 @@ module Lit
     end
 
     def get_value
-      (is_changed? && (!translated_value.nil?)) ? translated_value : default_value
+      is_changed? && !translated_value.nil? ? translated_value : default_value
     end
 
     def value
@@ -63,8 +63,12 @@ module Lit
 
     def update_default_value(value)
       return true if persisted? && default_value == value
-      self.default_value = value
-      self.save!
+      if persisted?
+        update_column(:default_value, value)
+      else
+        self.default_value = value
+        save!
+      end
     end
 
     private

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -207,9 +207,6 @@ module Lit
                   end
                 end
               end
-              if value.nil? && Lit.humanize_key
-                value = key_without_locale.split('.').last.humanize
-              end
             end
             localization.update_default_value(value)
           end

--- a/test/functional/welcome_controller_test.rb
+++ b/test/functional/welcome_controller_test.rb
@@ -6,7 +6,21 @@ class WelcomeControllerTest < ActionController::TestCase
     get :index, locale: :en
     assert_response :success
     assert I18n.locale == :en
+  end
+
+  test 'should properly load value from yaml' do
+    get :index, locale: :en
     assert Lit::LocalizationKey.where(localization_key: 'date.abbr_day_names').exists?
     assert_equal I18n.t('date.abbr_day_names'), %w( Sun Mon Tue Wed Thu Fri Sat )
+  end
+
+  test 'should properly store key with default value' do
+    get :index, locale: :en
+    localization_key = Lit::LocalizationKey.where(localization_key: 'scope.text_with_default').first
+    assert localization_key.present?
+    locale = Lit::Locale.find_by(locale: :en)
+    localization = localization_key.localizations.find_by(locale_id: locale.id)
+    assert_equal localization.get_value, 'Default content'
+    assert_equal localization.to_s, 'Default content'
   end
 end

--- a/test/integration/lit/projects_test.rb
+++ b/test/integration/lit/projects_test.rb
@@ -7,6 +7,7 @@ class ProjectsTest < ActionDispatch::IntegrationTest
     locale = Lit::Locale.where('locale=?', 'en').first
     localization_key = Lit::LocalizationKey.find_by_localization_key! 'helpers.label.project.name'
     localization = localization_key.localizations.where(locale_id: locale.id).first
+    assert_equal 'Name', localization.to_s
     assert_equal 'Name', localization.default_value
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,10 @@ end
 
 class ActionController::TestCase
   include Warden::Test::Helpers
-  include Devise::TestHelpers
+  if defined?(Devise::Test::ControllerHelpers)
+    include Devise::Test::ControllerHelpers
+  else
+    include Devise::TestHelpers
+  end
   Warden.test_mode!
 end


### PR DESCRIPTION
… as last

As someone noticed recently, default values were not saved properly in some scenarios. I could not find the exact cause, but this at least prooves everything is fine.

I also decided to move humanize_key to the end of process of adding new translation from views. Up until now this had precedence over default, while it definitely should be opposite. 
