### PR TITLE
Fix problem with searching localization keys by translated value

### DIFF
--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -82,7 +82,7 @@ module Lit
         s = s.where(localization_key_col.matches(q))
       end
       if options[:key].present?
-        q = "%#{options[:key]}%"
+        q = Arel::Nodes.build_quoted("%#{options[:key]}%")
         q_underscore = "%#{options[:key].parameterize.underscore}%"
         cond = localization_key_col.matches(q).or(
             default_value_col.matches(q).or(


### PR DESCRIPTION
Arel serialize values for serialized columns in rails 5.0 and 5.1. See
example:

    Lit::Localization.arel_table['translated_value'].matches('%val%').to_sql # "lit_localizations"."translated_value" ILIKE '--- %val%\n...'

Fix it by using `Arel::Nodes.build_quoted`:

    Lit::Localization.arel_table['translated_value'].matches(Arel::Nodes.build_quoted('%val%')).to_sql # => "lit_localizations"."translated_value" ILIKE '%val%'