### PR TITLE
Fix lit unscoped translations

### DIFF
--- a/app/views/lit/localization_keys/_localization_row.html.erb
+++ b/app/views/lit/localization_keys/_localization_row.html.erb
@@ -6,7 +6,7 @@
   </ul>
 <% else %>
   <% if localization.nil? %>
-    <em title="<%= I18n.t('.value_not_yet_translated', default: 'Value not yet translated') %>">null</em>
+    <em title="<%= I18n.t('lit.value_not_yet_translated', default: 'Value not yet translated') %>">null</em>
   <% else %>
     <%= localization %>
   <% end %>

--- a/app/views/lit/localization_keys/index.html.erb
+++ b/app/views/lit/localization_keys/index.html.erb
@@ -1,4 +1,4 @@
-<h3><%= I18n.t('.header', default: 'Localization keys') %></h3>
+<h3><%= I18n.t('lit.header', default: 'Localization keys') %></h3>
 <% available_locales = I18n.backend.available_locales %>
 
 <table class="table">


### PR DESCRIPTION
The translations `.value_not_yet_translated` and `.header` were not properly scoped, resulting in them being toplevel.