### PR TITLE
Translate everything

### DIFF
--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -1,23 +1,5 @@
 module Lit
   module FrontendHelper
-    include ActionView::Helpers::TranslationHelper
-    module TranslationKeyWrapper
-      def translate(key, options = {})
-        options = options.with_indifferent_access
-        key = scope_key_by_partial(key)
-        ret = super(key, options)
-        if !options[:skip_lit] && lit_authorized?
-          ret = get_translateable_span(key, ret)
-        end
-        ret
-      end
-
-      def t(key, options = {})
-        translate(key, options)
-      end
-    end
-    prepend Lit::FrontendHelper::TranslationKeyWrapper
-
     def javascript_lit_tag
       javascript_include_tag 'lit/lit_frontend'
     end

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -17,13 +17,12 @@ module Lit
     end
 
     def translate(locale, key, options = {})
-      options[:lit_default_copy] = options[:default].dup if can_dup_default(options)
       content = super(locale, key, options)
-      if Lit.all_translations_are_html_safe && content.respond_to?(:html_safe)
-        content.html_safe
-      else
-        content
-      end
+      content.blank? ? content : spanify(content, locale, key)
+    end
+
+    def spanify(content, locale, key)
+      format('<span class="lit-key-generic" data-key="%s" data-locale="%s">%s</span>', key, locale, content).html_safe
     end
 
     def available_locales


### PR DESCRIPTION
Hello,

**Don't merge this!**

This is just me musing with an idea: having all strings translatable in the web UI.

Basically, do the `<span>` in the `I18n.backend` instead of the frontend. That way, strings from `simple_form` and everything else that uses `I18n.t` are also available for inline editing.

What do you think of it? Is this something that'd interest you? I'm not sure it's really feasible without breaking other things.