### PR TITLE
Various improvements

### DIFF
--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -11,11 +11,10 @@
     var meta = $('meta[name="lit-url-base"]');
     if(meta.length > 0){
       getLocalizationPath($this, meta);
-      //replaceWithForm(e.currentTarget, value, update_path)
     }
     e.stopPropagation();
     return false;
-  }
+  };
 
   getLocalizationPath = function(elem, metaElem) {
     $.getJSON(metaElem.attr('value'),
@@ -38,7 +37,7 @@
   replaceWithForm = function(elem, value, update_path){
     removeLitForm();
     var $this = $(elem);
-    $this.attr('contentEditable', true);
+    $this.attr('contenteditable', true);
     $this.html( value );
     $this.focus();
     $this.on('blur', function(){
@@ -67,7 +66,7 @@
 
   removeLitForm = function(){
     $('#litForm').remove();
-  }
+  };
 
   $(document).ready(function(){
     $('<div id="lit_button_wrapper" />').appendTo('body');

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -12,6 +12,11 @@
     if(meta.length > 0){
       getLocalizationPath($this, meta);
     }
+    else
+    {
+      console.error('cannot lit base url');
+      alert('cannot lit base url');
+    }
     e.stopPropagation();
     return false;
   };
@@ -57,8 +62,8 @@
         console.log('saved ' + elem.data('key'));
       },
       error: function(){
-        console.log('problem saving ' + elem.data('key'));
-        alert('ups, ops, something went wrong');
+        console.error('cannot save ' + elem.data('key'));
+        alert('cannot save ' + elem.data('key'));
       }
     });
   };

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -38,7 +38,6 @@
     removeLitForm();
     var $this = $(elem);
     $this.attr('contenteditable', true);
-    $this.html( value );
     $this.focus();
     $this.on('blur', function(){
       submitForm($this, $this.html(), update_path);

--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -10,6 +10,7 @@ module Lit
               rescue I18n::MissingTranslationData
                 key.split('.')[-1].humanize rescue key
               end
+        key = pluralize_key(key, options[:count]) if options[:count]
         if !options[:skip_lit] && lit_authorized?
           ret = get_translateable_span(key, ret)
         end
@@ -18,6 +19,17 @@ module Lit
 
       def t(key, options = {})
         translate(key, options)
+      end
+
+      def pluralize_key(key, count)
+        key + case count
+              when 0
+                '.zero'
+              when 1
+                '.one'
+              else
+                '.other'
+              end
       end
     end
     prepend Lit::FrontendHelper::TranslationKeyWrapper

--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -5,7 +5,11 @@ module Lit
       def translate(key, options = {})
         options = options.with_indifferent_access
         key = scope_key_by_partial(key)
-        ret = super(key, options)
+        ret = begin
+                super(key, options.merge(raise: true))
+              rescue I18n::MissingTranslationData
+                key.split('.')[-1].humanize rescue key
+              end
         if !options[:skip_lit] && lit_authorized?
           ret = get_translateable_span(key, ret)
         end

--- a/lib/generators/lit/install/templates/initializer.rb
+++ b/lib/generators/lit/install/templates/initializer.rb
@@ -47,7 +47,7 @@ Lit.set_last_updated_at_upon_creation = true
 
 # Store request info - this will store in cache additional info about request
 # path that triggered translation key to be displayed / accessed
-# For more infor please check README.md
+# For more information please check the README.md
 Lit.store_request_info = false
 
 # Initialize lit

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -69,7 +69,7 @@ module Lit
       parts = I18n.normalize_keys(locale, key, scope, options[:separator])
       key_with_locale = parts.join('.')
 
-      ## check in cache or in simple backend
+      # check in cache or in simple backend
       content = @cache[key_with_locale] || super
       return content if parts.size <= 1
 
@@ -116,7 +116,7 @@ module Lit
           end
         end
       end
-      ## return translated content
+      # return translated content
       content
     end
 


### PR DESCRIPTION
Hello,

I think most of them are straightforward, the last commit https://github.com/prograils/lit/commit/dafc11dacb1d0247f274baa10710b8fffccee075 allows me to do this in order to get clean simple_form translations:

``` ruby
class ActionController::Base
  def render(*args)
    Rails.application.config.helpers = helpers
    super
  end
end

module SimpleForm
  module Components
    module Labels
      def label_translation
        Rails.application.config.helpers.t(format('activerecord.attributes.%s.%s', object.class.to_s.downcase, reflection_or_attribute_name.to_s))
      end
    end
  end
end
```

Without the last commit I get the "translation missing" texts from I18n and then the spans from rails `t()`.