### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You may also give it extra env variables to limit the export results.
 $ LOCALES=en,de rake lit:export
 ```
 
+Using the task `lit:export_splitted` does the same as `lit:export` but splits the locales by their name (`config/locales/en.yml`, etc).
 
 ### 0.2 -> 0.3 upgrade guide
 

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -7,7 +7,13 @@
     replaceWithForm, submitForm, removeLitForm;
 
   buildLocalizationForm = function(e){
+    e.stopPropagation();
+
     var $this = $(this);
+
+    if($this.is(':focus'))
+      return false;
+
     var meta = $('meta[name="lit-url-base"]');
 
     if(meta.length > 0)
@@ -15,7 +21,6 @@
     else
       console.error('cannot find lit base url');
 
-    e.stopPropagation();
     return false;
   };
 

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -11,11 +11,10 @@
     var meta = $('meta[name="lit-url-base"]');
     if(meta.length > 0){
       getLocalizationPath($this, meta);
-      //replaceWithForm(e.currentTarget, value, update_path)
     }
     e.stopPropagation();
     return false;
-  }
+  };
 
   getLocalizationPath = function(elem, metaElem) {
     $.getJSON(metaElem.attr('value'),
@@ -38,7 +37,7 @@
   replaceWithForm = function(elem, value, update_path){
     removeLitForm();
     var $this = $(elem);
-    $this.attr('contentEditable', true);
+    $this.attr('contenteditable', true);
     $this.html( value );
     $this.focus();
     $this.on('blur', function(){
@@ -67,7 +66,7 @@
 
   removeLitForm = function(){
     $('#litForm').remove();
-  }
+  };
 
   $(document).ready(function(){
     $('<div id="lit_button_wrapper" />').appendTo('body');

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -78,14 +78,14 @@
     $btn.on('click', function(){
       removeLitForm();
       if($btn.hasClass('lit-highlight-enabled')){
-        $('.lit-key-generic').removeClass('lit-key-highlight').off('click.form');
+        $('.lit-key-generic').removeClass('lit-key-highlight').off('click.lit');
         $btn.removeClass('lit-highlight-enabled');
         $('.lit-key-generic').each(function(_, elem){
           $elem = $(elem);
           $elem.attr('title', $elem.data('old-title') || '');
         });
       }else{
-        $('.lit-key-generic').addClass('lit-key-highlight').on('click.form', buildLocalizationForm);
+        $('.lit-key-generic').addClass('lit-key-highlight').on('click.lit', buildLocalizationForm);
         $btn.addClass('lit-highlight-enabled');
         $('.lit-key-generic').each(function(_, elem){
           $elem = $(elem);

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -38,7 +38,8 @@
     removeLitForm();
     var $this = $(elem);
     $this.attr('contenteditable', true);
-    $this.html( value );
+    if(value)
+      $this.html(value);
     $this.focus();
     $this.on('blur', function(){
       submitForm($this, $this.html(), update_path);

--- a/app/assets/javascripts/lit/lit_frontend.js
+++ b/app/assets/javascripts/lit/lit_frontend.js
@@ -9,9 +9,12 @@
   buildLocalizationForm = function(e){
     var $this = $(this);
     var meta = $('meta[name="lit-url-base"]');
-    if(meta.length > 0){
+
+    if(meta.length > 0)
       getLocalizationPath($this, meta);
-    }
+    else
+      console.error('cannot find lit base url');
+
     e.stopPropagation();
     return false;
   };
@@ -59,8 +62,8 @@
         console.log('saved ' + elem.data('key'));
       },
       error: function(){
-        console.log('problem saving ' + elem.data('key'));
-        alert('ups, ops, something went wrong');
+        console.error('cannot save ' + elem.data('key'));
+        alert('cannot save ' + elem.data('key'));
       }
     });
   };

--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -5,11 +5,12 @@ module Lit
       def translate(key, options = {})
         options = options.with_indifferent_access
         key = scope_key_by_partial(key)
-        ret = super(key, options)
+        content = super(key, options)
+
         if !options[:skip_lit] && lit_authorized?
-          ret = get_translateable_span(key, ret)
+          content = get_translateable_span(key, content)
         end
-        ret
+        content
       end
 
       def t(key, options = {})

--- a/app/views/kaminari/lit/_gap.html.erb
+++ b/app/views/kaminari/lit/_gap.html.erb
@@ -1,3 +1,3 @@
 <li class="page gap disabled">
-  <a href="#" onclick="return false;"><%= raw t('views.pagination.truncate') %></a>
+  <a href="#" onclick="return false;"><%= raw I18n.t('views.pagination.truncate') %></a>
 </li>

--- a/app/views/lit/dashboard/index.html.erb
+++ b/app/views/lit/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <strong>All localization keys</strong> <%= Lit::LocalizationKey.count(:id) %><br/>
 <% @locales.each do |l| %>
-  <strong><%= image_tag "lit/famfamfam_flags/#{l.locale[0,2]}.png" %> <%= t("lit.locale_to_languages.#{l.locale}", :default=>l.locale) %>:</strong> <span title="<%= "#{l.get_changed_localizations_count}/#{l.get_all_localizations_count}" %>"><%= l.get_translated_percentage %>%</span><br/>
+  <strong><%= image_tag "lit/famfamfam_flags/#{l.locale[0,2]}.png" %> <%= I18n.t("lit.locale_to_languages.#{l.locale}", :default=>l.locale) %>:</strong> <span title="<%= "#{l.get_changed_localizations_count}/#{l.get_all_localizations_count}" %>"><%= l.get_translated_percentage %>%</span><br/>
 <% end %>
 

--- a/app/views/lit/incomming_localizations/index.html.erb
+++ b/app/views/lit/incomming_localizations/index.html.erb
@@ -5,10 +5,10 @@
     <h4 class="<%= source_loading_class(@source) %>">Synchronization in progress, please wait. The page will refresh automatically when done.</h2>
     <span class="pull-right">
       <%= link_to accept_all_source_incomming_localizations_path(@source), :class=>"btn btn-success btn-sm", :data=>{:confirm=>t('lit.common.you_sure', :default=>"Are you sure?")} do %>
-        <%= t('lit.common.accept_all', :default=>"Accept all") %>
+        <%= I18n.t('lit.common.accept_all', :default=>"Accept all") %>
       <% end %>
       <%= link_to reject_all_source_incomming_localizations_path(@source), :class=>"btn btn-danger btn-sm", :method=>:post, :data=>{:confirm=>t('lit.common.you_sure', :default=>"Are you sure?")} do %>
-        <%= t('lit.common.reject_all', :default=>"Reject all") %>
+        <%= I18n.t('lit.common.reject_all', :default=>"Reject all") %>
       <% end %>
     </span>
   </div>
@@ -40,7 +40,7 @@
       <td>
         <%= link_to accept_source_incomming_localization_path(@source, il, format: :js), class: 'btn btn-success btn-sm', remote: true do %>
           <%= draw_icon 'check', class: 'icon-white' %>
-          <%= t('lit.common.accept', default: 'Accept') %>
+          <%= I18n.t('lit.common.accept', default: 'Accept') %>
         <% end %>
         <%= link_to source_incomming_localization_path(@source, il, format: :js), class: 'btn btn-danger btn-sm', remote: true, method: :delete, data: {confirm: I18n.t('lit.common.you_sure', default: 'Are you sure?')} do %>
           <%= draw_icon 'times', class: "icon-white" %>

--- a/app/views/lit/localization_keys/index.html.erb
+++ b/app/views/lit/localization_keys/index.html.erb
@@ -16,7 +16,7 @@
           <%= link_to lit.star_localization_key_path(lk), remote: true, class: 'star_icon title', title: 'Star / unstar translation key' do %>
             <%= draw_icon lk.is_starred? ? 'star' : 'star-o' %>
           <% end %>
-          <%= link_to lit.localization_key_path(lk), method: :delete, data: {confirm: t('lit.common.you_sure', default: "Are you sure?")}, remote: true, title: 'Delete translation key', class: 'title' do %>
+          <%= link_to lit.localization_key_path(lk), method: :delete, data: {confirm: I18n.t('lit.common.you_sure', default: "Are you sure?")}, remote: true, title: 'Delete translation key', class: 'title' do %>
             <%= draw_icon 'trash-o' %>
           <% end %>
         </div>
@@ -81,7 +81,7 @@
       </div>
       <label class="checkbox">
         <%= check_box_tag :include_completed, '1', @search_options[:include_completed].to_i==1 %>
-        <%= t('.is_completed', :default=>"Include completed") %>
+        <%= I18n.t('.is_completed', :default=>"Include completed") %>
       </label>
     <% end %>
     <ul class="nav nav-pills nav-stacked">
@@ -97,11 +97,11 @@
           starred
         <% end %>
       </li>
-      <li class="nav-header"><%= t(".order_by", :default => "Order by") %>:</li>
+      <li class="nav-header"><%= I18n.t(".order_by", :default => "Order by") %>:</li>
       <% Lit::LocalizationKey.order_options.each do |order| %>
         <li class="<%= "active" if order == @search_options[:order]  %>">
           <%= link_to url_for(@search_options.merge(:order => order)) do %>
-            <%= t("lit.order_options.#{order.gsub(" ", "_")}", :default => order.humanize) %>
+            <%= I18n.t("lit.order_options.#{order.gsub(" ", "_")}", :default => order.humanize) %>
           <% end %>
         </li>
       <% end %>

--- a/app/views/lit/localizations/_previous_versions_rows.html.erb
+++ b/app/views/lit/localizations/_previous_versions_rows.html.erb
@@ -1,8 +1,8 @@
 <span class="pull-right"><%= draw_icon 'times', :class=>"close_versions" %></span>
 <table class="table table-condensed">
   <tr>
-    <th><%= t('lit.common.previous_versions') %></th>
-    <th width="25%"><%= t('lit.common.changed_at') %></th>
+    <th><%= I18n.t('lit.common.previous_versions') %></th>
+    <th width="25%"><%= I18n.t('lit.common.changed_at') %></th>
   </tr>
   <% @versions.each do |v| %>
     <tr>

--- a/app/views/lit/sources/_form.html.erb
+++ b/app/views/lit/sources/_form.html.erb
@@ -30,6 +30,6 @@
   </div>
 
   <div class="actions">
-    <%= f.submit t('lit.common.save', :default => "Save"), :class=>"btn btn-primary btn-sm" %>
+    <%= f.submit I18n.t('lit.common.save', :default => "Save"), :class=>"btn btn-primary btn-sm" %>
   </div>
 <% end %>

--- a/lib/generators/lit/install/templates/initializer.rb
+++ b/lib/generators/lit/install/templates/initializer.rb
@@ -47,7 +47,7 @@ Lit.set_last_updated_at_upon_creation = true
 
 # Store request info - this will store in cache additional info about request
 # path that triggered translation key to be displayed / accessed
-# For more infor please check README.md
+# For more information please check the README.md
 Lit.store_request_info = false
 
 # Initialize lit

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -69,7 +69,7 @@ module Lit
       parts = I18n.normalize_keys(locale, key, scope, options[:separator])
       key_with_locale = parts.join('.')
 
-      ## check in cache or in simple backend
+      # check in cache or in simple backend
       content = @cache[key_with_locale] || super
       return content if parts.size <= 1
 
@@ -116,7 +116,7 @@ module Lit
           end
         end
       end
-      ## return translated content
+      # return translated content
       content
     end
 

--- a/lib/tasks/lit_tasks.rake
+++ b/lib/tasks/lit_tasks.rake
@@ -8,6 +8,16 @@ namespace :lit do
     end
   end
 
+  desc 'Exports translated strings from lit to config/locales/%{locale}.yml file.'
+  task export_splitted: :environment do
+    hash = YAML.load(Lit.init.cache.export)
+    hash.keys.each do |locale|
+      path = Rails.root.join('config', 'locales', format('%s.yml', locale))
+      File.write(path, hash.slice(locale).to_yaml)
+      puts format('Successfully exported %s.', path)
+    end
+  end
+
   desc 'Reads config/locales/#{ENV["FILES"]} files and calls I18n.t() on keys forcing Lit to import given LOCALE to cache / to display them in UI. Skips nils by default (change by setting ENV["SKIP_NIL"] = false'
   task raw_import: :environment do
     return 'you need to define FILES env' if ENV['FILES'].blank?

--- a/lib/tasks/lit_tasks.rake
+++ b/lib/tasks/lit_tasks.rake
@@ -26,4 +26,11 @@ namespace :lit do
       end
     end
   end
+
+  desc 'Remove all translations'
+  task clear: :environment do
+    Lit::LocalizationKey.destroy_all
+    Lit::IncommingLocalization.destroy_all
+    Lit.init.cache.reset
+  end
 end


### PR DESCRIPTION
Hello,

I think most of them are straightforward, the last commit https://github.com/prograils/lit/commit/dafc11dacb1d0247f274baa10710b8fffccee075 allows me to do this in order to get clean simple_form translations:

``` ruby
class ActionController::Base
  def render(*args)
    Rails.application.config.helpers = helpers
    super
  end
end

module SimpleForm
  module Components
    module Labels
      def label_translation
        Rails.application.config.helpers.t(format('activerecord.attributes.%s.%s', object.class.to_s.downcase, reflection_or_attribute_name.to_s))
      end
    end
  end
end
```

Otherwise I get "translation missing" texts from I18n and then the spans from rails `t()`.