### PR TITLE
Deleted localizations synchronization

### DIFF
--- a/app/controllers/lit/api/v1/base_controller.rb
+++ b/app/controllers/lit/api/v1/base_controller.rb
@@ -3,7 +3,7 @@ module Lit
     module V1
       class BaseController < ActionController::Base
         layout nil
-        respond_to :json
+        respond_to :json if ::Rails::VERSION::MAJOR < 5
         before_action :authenticate_requests!
 
         private

--- a/app/controllers/lit/api/v1/localization_keys_controller.rb
+++ b/app/controllers/lit/api/v1/localization_keys_controller.rb
@@ -4,8 +4,9 @@ module Lit
   class Api::V1::LocalizationKeysController < Api::V1::BaseController
     def index
       @localization_keys = fetch_localization_keys
-      render json: @localization_keys.as_json(root: false,
-                                              only: %i[id localization_key])
+      render json: @localization_keys.as_json(
+        root: false, only: %i[id localization_key is_deleted]
+      )
     end
 
     private

--- a/app/controllers/lit/api/v1/localizations_controller.rb
+++ b/app/controllers/lit/api/v1/localizations_controller.rb
@@ -5,12 +5,15 @@ module Lit
       render json: @localizations.as_json(
         root: false,
         only: %i[id localization_key_id locale_id],
-        methods: %i[value localization_key_str locale_str]
+        methods: %i[
+          value localization_key_str locale_str
+          localization_key_is_deleted
+        ]
       )
     end
 
     def last_change
-      @localization = Localization.order('updated_at DESC').first
+      @localization = Localization.order(updated_at: :desc).first
       render json: @localization.as_json(
         root: false, only: [], methods: [:last_change]
       )

--- a/app/controllers/lit/api/v1/localizations_controller.rb
+++ b/app/controllers/lit/api/v1/localizations_controller.rb
@@ -23,7 +23,8 @@ module Lit
 
     def fetch_localizations
       if params[:after].present?
-        after_date = Time.parse(params[:after])
+        after_date = Time.parse("#{params[:after]} #{Time.zone.name}")
+                         .in_time_zone
         Localization.after(after_date).to_a
       else
         Localization.all

--- a/app/controllers/lit/incomming_localizations_controller.rb
+++ b/app/controllers/lit/incomming_localizations_controller.rb
@@ -16,7 +16,9 @@ module Lit
     end
 
     def accept_all
-      @incomming_localizations.each(&:accept)
+      ActiveRecord::Base.transaction do
+        @incomming_localizations.each(&:accept)
+      end
       finish_request
     end
 

--- a/app/controllers/lit/incomming_localizations_controller.rb
+++ b/app/controllers/lit/incomming_localizations_controller.rb
@@ -2,16 +2,13 @@ require_dependency 'lit/application_controller'
 
 module Lit
   class IncommingLocalizationsController < ApplicationController
-    before_action :find_source
+    before_action :find_source_and_incomming_localizations
     before_action :find_icomming_localization, only: %i[accept destroy]
 
-    def index
-      @incomming_localizations = @source.incomming_localizations
-    end
+    def index; end
 
     def accept
       @incomming_localization.accept
-      Lit.init.cache.refresh_key @incomming_localization.full_key
       respond_to do |format|
         format.html { finish_request }
         format.js
@@ -19,15 +16,12 @@ module Lit
     end
 
     def accept_all
-      @source.incomming_localizations.each do |li|
-        li.accept
-        Lit.init.cache.refresh_key li.full_key
-      end
+      @incomming_localizations.each(&:accept)
       finish_request
     end
 
     def reject_all
-      @source.incomming_localizations.destroy_all
+      @incomming_localizations.destroy_all
       finish_request
     end
 
@@ -46,8 +40,9 @@ module Lit
                                        .find(params[:id].to_i)
     end
 
-    def find_source
+    def find_source_and_incomming_localizations
       @source = Source.find(params[:source_id].to_i)
+      @incomming_localizations = @source.incomming_localizations
     end
 
     def finish_request

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -49,6 +49,7 @@ module Lit
 
     def destroy
       @localization_key.update is_deleted: true
+      @localization_key.localizations.each { |loc| loc.update is_changed: true }
       I18n.backend.available_locales.each do |l|
         Lit.init.cache.delete_key "#{l}.#{@localization_key.localization_key}"
       end

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -48,7 +48,7 @@ module Lit
     end
 
     def destroy
-      @localization_key.destroy
+      @localization_key.update is_deleted: true
       I18n.backend.available_locales.each do |l|
         Lit.init.cache.delete_key "#{l}.#{@localization_key.localization_key}"
       end
@@ -67,7 +67,7 @@ module Lit
                         else
                           params.slice(*valid_keys)
                         end
-      @scope = LocalizationKey.distinct
+      @scope = LocalizationKey.distinct.active
                               .preload(localizations: :locale)
                               .search(@search_options)
     end
@@ -125,7 +125,7 @@ module Lit
     def versions?(localization)
       @_versions ||= begin
         ids = grouped_localizations.values.map(&:values).flatten.map(&:id)
-        Lit::Localization.where(id: ids).joins(:versions).group(
+        Lit::Localization.active.where(id: ids).joins(:versions).group(
           "#{Lit::Localization.quoted_table_name}.id"
         ).count
       end

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -3,7 +3,7 @@ module Lit
     before_action :find_localization_scope,
                   except: %i[destroy find_localization]
     before_action :find_localization_key,
-                  only: %i[star destroy change_completed]
+                  only: %i[star destroy change_completed restore_deleted]
 
     def index
       get_localization_keys
@@ -11,6 +11,11 @@ module Lit
 
     def not_translated
       @scope = @scope.not_completed
+      get_localization_keys
+    end
+
+    def visited_again
+      @scope = @scope.unscope(where: :is_deleted).not_active.visited_again
       get_localization_keys
     end
 
@@ -44,6 +49,11 @@ module Lit
 
     def change_completed
       @localization_key.change_all_completed
+      respond_to :js
+    end
+
+    def restore_deleted
+      @localization_key.restore
       respond_to :js
     end
 

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -48,11 +48,7 @@ module Lit
     end
 
     def destroy
-      @localization_key.update is_deleted: true
-      @localization_key.localizations.each { |loc| loc.update is_changed: true }
-      I18n.backend.available_locales.each do |l|
-        Lit.init.cache.delete_key "#{l}.#{@localization_key.localization_key}"
-      end
+      @localization_key.soft_destroy
       respond_to :js
     end
 

--- a/app/controllers/lit/localizations_controller.rb
+++ b/app/controllers/lit/localizations_controller.rb
@@ -38,7 +38,7 @@ module Lit
 
     def find_localization_key
       @localization_key =
-        Lit::LocalizationKey.find(params[:localization_key_id])
+        Lit::LocalizationKey.active.find(params[:localization_key_id])
     end
 
     def find_localization

--- a/app/controllers/lit/sources_controller.rb
+++ b/app/controllers/lit/sources_controller.rb
@@ -27,7 +27,7 @@ module Lit
 
     def touch
       @source.touch_last_updated_at!
-      redirect_to_back_or_default fallback_location: sources_url(@source)
+      redirect_to_back_or_default fallback_location: source_path(@source)
     end
 
     def create

--- a/app/controllers/lit/sources_controller.rb
+++ b/app/controllers/lit/sources_controller.rb
@@ -27,7 +27,7 @@ module Lit
 
     def touch
       @source.touch_last_updated_at!
-      redirect_to request.env['HTTP_REFERER'].present? ? :back : @source
+      redirect_to_back_or_default fallback_location: sources_url(@source)
     end
 
     def create

--- a/app/models/lit/incomming_localization.rb
+++ b/app/models/lit/incomming_localization.rb
@@ -34,8 +34,7 @@ module Lit
     end
 
     def duplicated?(val)
-      set_localization unless localization.present?
-      return false unless localization
+      return false if localization_has_changed?
       translated_value =
         localization.read_attribute_before_type_cast('translated_value')
       if localization.is_changed? && !translated_value.nil?
@@ -48,9 +47,16 @@ module Lit
     private
 
     def set_localization
-      return if locale.blank? || localization_key.blank?
+      return if localization.blank? || locale.blank? ||
+                localization_key.blank?
       self.localization = localization_key.localizations
                                           .find_by(locale_id: locale_id)
+    end
+
+    def localization_has_changed?
+      set_localization
+      localization.blank? ||
+        localization.is_deleted != localization_key_is_deleted
     end
 
     def update_existing_localization_data

--- a/app/models/lit/incomming_localization.rb
+++ b/app/models/lit/incomming_localization.rb
@@ -34,6 +34,7 @@ module Lit
     end
 
     def duplicated?(val)
+      set_localization
       return false if localization_has_changed?
       translated_value =
         localization.read_attribute_before_type_cast('translated_value')
@@ -47,14 +48,12 @@ module Lit
     private
 
     def set_localization
-      return if localization.blank? || locale.blank? ||
-                localization_key.blank?
+      return if locale.blank? || localization_key.blank?
       self.localization = localization_key.localizations
                                           .find_by(locale_id: locale_id)
     end
 
     def localization_has_changed?
-      set_localization
       localization.blank? ||
         localization.is_deleted != localization_key_is_deleted
     end

--- a/app/models/lit/locale.rb
+++ b/app/models/lit/locale.rb
@@ -29,11 +29,11 @@ module Lit
     end
 
     def changed_localizations_count
-      localizations.changed.count(:id)
+      localizations.active.changed.count(:id)
     end
 
     def all_localizations_count
-      localizations.count(:id)
+      localizations.active.count(:id)
     end
 
     private

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -22,6 +22,9 @@ module Lit
     has_many :localization_versions, dependent: :destroy
     has_many :versions, class_name: '::Lit::LocalizationVersion'
 
+    ## DELEGATIONS
+    delegate :is_deleted, to: :localization_key
+
     ## VALIDATIONS
     validates :locale, presence: true
 

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -11,6 +11,10 @@ module Lit
       where('updated_at >= ?', dt + 1.second)
         .where(is_changed: true)
     }
+    scope :active, lambda {
+      joins(:localization_key)
+        .where(Lit::LocalizationKey.table_name => { is_deleted: false })
+    }
 
     ## ASSOCIATIONS
     belongs_to :locale
@@ -50,6 +54,10 @@ module Lit
 
     def localization_key_str
       localization_key.localization_key
+    end
+
+    def localization_key_is_deleted
+      localization_key.is_deleted
     end
 
     def locale_str

--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -7,6 +7,7 @@ module Lit
     scope :not_completed, -> { where(is_completed: false) }
     scope :starred, -> { where(is_starred: true) }
     scope :ordered, -> { order(localization_key: :asc) }
+    scope :active, -> { where(is_deleted: false) }
     scope :after, lambda { |dt|
       joins(:localizations)
         .where('lit_localization_keys.updated_at >= ?', dt)

--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -69,6 +69,16 @@ module Lit
       end
     end
 
+    def soft_destroy
+      ActiveRecord::Base.transaction do
+        update is_deleted: true
+        change_all_completed
+        I18n.backend.available_locales.each do |l|
+          Lit.init.cache.delete_key "#{l}.#{localization_key}"
+        end
+      end
+    end
+
     private
 
     def check_completed

--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -8,6 +8,8 @@ module Lit
     scope :starred, -> { where(is_starred: true) }
     scope :ordered, -> { order(localization_key: :asc) }
     scope :active, -> { where(is_deleted: false) }
+    scope :not_active, -> { where(is_deleted: true) }
+    scope :visited_again, -> { where(is_visited_again: true) }
     scope :after, lambda { |dt|
       joins(:localizations)
         .where('lit_localization_keys.updated_at >= ?', dt)
@@ -76,6 +78,13 @@ module Lit
         I18n.backend.available_locales.each do |l|
           Lit.init.cache.delete_key "#{l}.#{localization_key}"
         end
+      end
+    end
+
+    def restore
+      ActiveRecord::Base.transaction do
+        update is_deleted: false, is_completed: false, is_visited_again: false
+        localizations.update_all is_changed: false
       end
     end
 

--- a/app/models/lit/source.rb
+++ b/app/models/lit/source.rb
@@ -30,11 +30,11 @@ module Lit
     end
 
     def touch_last_updated_at!
-      touch_last_updated_at
+      assign_last_updated_at
       save
     end
 
-    def touch_last_updated_at(time = nil)
+    def assign_last_updated_at(time = nil)
       self.last_updated_at = time || Time.now
     end
 
@@ -48,7 +48,7 @@ module Lit
 
     def set_last_updated_at_upon_creation
       return if last_updated_at.blank? && !Lit.set_last_updated_at_upon_creation
-      touch_last_updated_at
+      assign_last_updated_at
     end
   end
 end

--- a/app/services/synchronize_source_service.rb
+++ b/app/services/synchronize_source_service.rb
@@ -20,7 +20,6 @@ class SynchronizeSourceService
 
   def synchronize_localization(loc)
     inc_loc = find_incomming_localization(loc)
-    return if inc_loc.duplicated?(loc['value'])
     inc_loc.source = @source
     inc_loc.locale_str = loc['locale_str']
     inc_loc.locale = Lit::Locale.find_by(locale: loc['locale_str'])
@@ -28,6 +27,7 @@ class SynchronizeSourceService
     inc_loc.localization_key_is_deleted = localization_key_deleted?(loc)
     inc_loc.localization_key = find_localization_key(inc_loc)
     inc_loc.translated_value = loc['value']
+    return if inc_loc.duplicated?(loc['value'])
     inc_loc.save!
   end
 

--- a/app/services/synchronize_source_service.rb
+++ b/app/services/synchronize_source_service.rb
@@ -48,11 +48,13 @@ class SynchronizeSourceService
   end
 
   def update_timestamps
-    last_change = @source.last_change
-    last_change = Time.parse(last_change) if last_change.present?
-    @source.assign_last_updated_at(last_change)
+    @source.assign_last_updated_at(fetch_last_change)
     @source.sync_complete = true
     @source.save!
+  end
+
+  def fetch_last_change
+    interactor.send_request(Lit::Source::LAST_CHANGE_PATH)['last_change']
   end
 
   def interactor

--- a/app/views/lit/dashboard/index.html.erb
+++ b/app/views/lit/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<strong>All localization keys</strong> <%= Lit::LocalizationKey.count(:id) %><br/>
+<strong>All localization keys</strong> <%= Lit::LocalizationKey.active.count(:id) %><br/>
 <% @locales.each do |l| %>
   <strong><%= image_tag "lit/famfamfam_flags/#{l.locale[0,2]}.png" %> <%= I18n.t("lit.locale_to_languages.#{l.locale}", :default=>l.locale) %>:</strong> <span title="<%= "#{l.changed_localizations_count}/#{l.all_localizations_count}" %>"><%= l.translated_percentage %>%</span><br/>
 <% end %>

--- a/app/views/lit/incomming_localizations/index.html.erb
+++ b/app/views/lit/incomming_localizations/index.html.erb
@@ -19,6 +19,7 @@
   <tr>
     <th>Current value</th>
     <th>Imported value</th>
+    <th>Is deleted</th>
     <th width="200px"></th>
   </tr>
   <% @incomming_localizations.each do |il| %>
@@ -34,8 +35,11 @@
           <%= render partial: '/lit/localization_keys/localization_row', locals: {localization: il.localization.translation} %>
         <% end %>
       </td>
-      <Td>
+      <td>
         <%= render partial: '/lit/localization_keys/localization_row', locals: {localization: il.translation} %>
+      </td>
+      <td>
+        <%= il.localization_key_is_deleted %>
       </td>
       <td>
         <%= link_to accept_source_incomming_localization_path(@source, il, format: :js), class: 'btn btn-success btn-sm', remote: true do %>

--- a/app/views/lit/localization_keys/_localizations_list.html.erb
+++ b/app/views/lit/localization_keys/_localizations_list.html.erb
@@ -10,14 +10,21 @@
               <%= draw_icon 'link' %>
             <% end %>
           <% end %>
-          <%= link_to lit.change_completed_localization_key_path(lk), method: :put, remote: true, class: 'check_icon title', title: 'Complete / incomplete translation key' do %>
-            <%= draw_icon lk.is_starred? ? 'check-circle' : 'check-circle-o' %>
+          <% if lk.is_deleted? %>
+            <%= link_to lit.restore_deleted_localization_key_path(lk), method: :put, remote: true, class: 'rotate_left_icon title', title: 'Restore translation key' do %>
+              <%= draw_icon 'rotate-left' %>
+            <% end %>
           <% end %>
-          <%= link_to lit.star_localization_key_path(lk), remote: true, class: 'star_icon title', title: 'Star / unstar translation key' do %>
-            <%= draw_icon lk.is_starred? ? 'star' : 'star-o' %>
-          <% end %>
-          <%= link_to lit.localization_key_path(lk), method: :delete, data: {confirm: I18n.t('lit.common.you_sure', default: "Are you sure?")}, remote: true, title: 'Delete translation key', class: 'title' do %>
-            <%= draw_icon 'trash-o' %>
+          <% unless lk.is_deleted? %>
+            <%= link_to lit.change_completed_localization_key_path(lk), method: :put, remote: true, class: 'check_icon title', title: 'Complete / incomplete translation key' do %>
+              <%= draw_icon lk.is_starred? ? 'check-circle' : 'check-circle-o' %>
+            <% end %>
+            <%= link_to lit.star_localization_key_path(lk), remote: true, class: 'star_icon title', title: 'Star / unstar translation key' do %>
+              <%= draw_icon lk.is_starred? ? 'star' : 'star-o' %>
+            <% end %>
+            <%= link_to lit.localization_key_path(lk), method: :delete, data: {confirm: I18n.t('lit.common.you_sure', default: "Are you sure?")}, remote: true, title: 'Delete translation key', class: 'title' do %>
+              <%= draw_icon 'trash-o' %>
+            <% end %>
           <% end %>
         </div>
         <div class="detail_wrapper">
@@ -25,7 +32,9 @@
             <tr>
               <th class="col-md-8">Translation</th>
               <th class="col-md-2 text-center">Locale</th>
-              <th class="col-md-2 text-center">Completed</th>
+              <% unless lk.is_deleted? %>
+                <th class="col-md-2 text-center">Completed</th>
+              <% end %>
             </tr>
             <%- available_locales.each do |locale| %>
               <%- localization = localization_for(locale, lk) %>
@@ -42,11 +51,13 @@
                     <% end %>
                   <% end %>
                 </td>
-                <td class="text-center">
-                  <%= link_to lit.change_completed_localization_key_localization_path(lk, localization), method: :put, remote: true, class: "change_completed_#{localization.id}" do |f| %>
-                    <%= check_box_tag :is_changed, localization.is_changed, localization.is_changed %>
-                  <% end %>
-                </td>
+                <% unless lk.is_deleted? %>
+                  <td class="text-center">
+                    <%= link_to lit.change_completed_localization_key_localization_path(lk, localization), method: :put, remote: true, class: "change_completed_#{localization.id}" do |f| %>
+                      <%= check_box_tag :is_changed, localization.is_changed, localization.is_changed %>
+                    <% end %>
+                  </td>
+                <% end %>
               </tr>
               <tr class="hidden localization_versions_row" data-id="<%= localization.id %>">
                 <td colspan="2" class="localization_versions"></td>

--- a/app/views/lit/localization_keys/_sidebar.html.erb
+++ b/app/views/lit/localization_keys/_sidebar.html.erb
@@ -30,6 +30,12 @@
           starred
         <% end %>
       </li>
+      <li class="<%= "active" if params[:action]=='visited_again' %>">
+        <%= link_to lit.visited_again_localization_keys_path do -%>
+          <%= draw_icon 'undo' %>
+          deleted and visited again
+        <% end %>
+      </li>
       <li class="nav-header"><%= I18n.t(".order_by", :default => "Order by") %>:</li>
       <% Lit::LocalizationKey.order_options.each do |order| %>
         <li class="<%= "active" if order == @search_options[:order]  %>">

--- a/app/views/lit/localization_keys/restore_deleted.js.erb
+++ b/app/views/lit/localization_keys/restore_deleted.js.erb
@@ -1,0 +1,1 @@
+$('tr.localization_key_row[data-id="<%= @localization_key.id %>"]').fadeOut();

--- a/app/views/lit/localization_keys/visited_again.html.erb
+++ b/app/views/lit/localization_keys/visited_again.html.erb
@@ -1,0 +1,9 @@
+<h3><%= I18n.t('lit.visited_again_header', default: 'Deleted and visited again localization keys') %></h3>
+
+<%= render 'localizations_list', available_locales: I18n.backend.available_locales %>
+
+<% if defined?(Kaminari)  %>
+  <%= paginate @localization_keys, :theme=>"lit" %>
+<% end %>
+
+<%= render 'sidebar' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,11 +18,13 @@ Lit::Engine.routes.draw do
     member do
       get :star
       put :change_completed
+      put :restore_deleted
     end
     collection do
       get :starred
       get :find_localization
       get :not_translated
+      get :visited_again
     end
     resources :localizations, only: [:edit, :update, :show] do
       member do

--- a/db/migrate/20181017123839_lit_add_is_deleted_to_localization_keys.rb
+++ b/db/migrate/20181017123839_lit_add_is_deleted_to_localization_keys.rb
@@ -1,0 +1,8 @@
+class LitAddIsDeletedToLocalizationKeys < Rails::VERSION::MAJOR >= 5   ?
+                                       ActiveRecord::Migration[4.2] :
+                                       ActiveRecord::Migration
+  def change
+    add_column :lit_localization_keys, :is_deleted, :boolean,
+               default: false, null: false
+  end
+end

--- a/db/migrate/20181018075955_lit_add_localization_key_is_deleted_to_localization_keys.rb
+++ b/db/migrate/20181018075955_lit_add_localization_key_is_deleted_to_localization_keys.rb
@@ -1,0 +1,8 @@
+class LitAddLocalizationKeyIsDeletedToLocalizationKeys < Rails::VERSION::MAJOR >= 5   ?
+                                                      ActiveRecord::Migration[4.2] :
+                                                      ActiveRecord::Migration
+  def change
+    add_column :lit_incomming_localizations, :localization_key_is_deleted,
+               :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20181030111522_lit_add_is_visited_again_to_localization_keys.rb
+++ b/db/migrate/20181030111522_lit_add_is_visited_again_to_localization_keys.rb
@@ -1,0 +1,8 @@
+class LitAddIsVisitedAgainToLocalizationKeys < Rails::VERSION::MAJOR >= 5   ?
+                                               ActiveRecord::Migration[4.2] :
+                                               ActiveRecord::Migration
+  def change
+    add_column :lit_localization_keys, :is_visited_again, :boolean,
+               null: false, default: false
+  end
+end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -82,11 +82,11 @@ module Lit
     end
 
     def load_all_translations
-      first = Localization.order(id: :asc).first
-      last = Localization.order(id: :desc).first
+      first = Localization.active.order(id: :asc).first
+      last = Localization.active.order(id: :desc).first
       if !first || (!localizations.has_key?(first.full_key) ||
         !localizations.has_key?(last.full_key))
-        Localization.includes([:locale, :localization_key]).find_each do |l|
+        Localization.includes(%i[locale localization_key]).active.find_each do |l|
           localizations[l.full_key] = l.translation
         end
       end
@@ -190,8 +190,11 @@ module Lit
       return nil if value.is_a?(Hash)
       ActiveRecord::Base.transaction do
         localization_key = find_localization_key(key_without_locale)
-        localization = Lit::Localization.where(locale_id: locale.id). \
-                          where(localization_key_id: localization_key.id).first_or_initialize
+        localization =
+          Lit::Localization.active
+                           .where(locale_id: locale.id)
+                           .where(localization_key_id: localization_key.id)
+                           .first_or_initialize
         if update_value || localization.new_record?
           if value.is_a?(Array)
             value = parse_array_value(value) unless force_array
@@ -236,8 +239,8 @@ module Lit
     def find_localization_for_delete(locale, key_without_locale)
       localization_key = find_localization_key_for_delete(key_without_locale)
       return nil unless localization_key
-      Lit::Localization.find_by(locale_id: locale.id,
-                                localization_key_id: localization_key.id)
+      Lit::Localization.active.find_by(locale_id: locale.id,
+                                       localization_key_id: localization_key.id)
     end
 
     def delete_localization(locale, key_without_locale)
@@ -259,7 +262,7 @@ module Lit
         when Symbol then
           lk = Lit::LocalizationKey.where(localization_key: v.to_s).first
           if lk
-            loca = Lit::Localization.where(locale_id: locale.id).
+            loca = Lit::Localization.active.where(locale_id: locale.id).
                         where(localization_key_id: lk.id).first
             new_value = loca.translation if loca && loca.translation.present?
           end
@@ -286,10 +289,12 @@ module Lit
     end
 
     def find_localization_key(key_without_locale)
-      unless localization_keys.key?(key_without_locale)
-        find_or_create_localization_key(key_without_locale)
+      if localization_keys.key?(key_without_locale)
+        Lit::LocalizationKey.find_by(
+          id: localization_keys[key_without_locale]
+        ) || find_or_create_localization_key(key_without_locale)
       else
-        Lit::LocalizationKey.find_by(id: localization_keys[key_without_locale]) || find_or_create_localization_key(key_without_locale)
+        find_or_create_localization_key(key_without_locale)
       end
     end
 
@@ -303,7 +308,9 @@ module Lit
     end
 
     def find_or_create_localization_key(key_without_locale)
-      localization_key = Lit::LocalizationKey.where(localization_key: key_without_locale).first_or_create!
+      localization_key = Lit::LocalizationKey.find_or_create_by!(
+        localization_key: key_without_locale
+      )
       localization_keys[key_without_locale] = localization_key.id
       localization_key
     end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -311,10 +311,8 @@ module Lit
       localization_key = Lit::LocalizationKey.find_or_initialize_by(
         localization_key: key_without_locale
       )
-      if localization_key.is_deleted?
-        localization_key.is_visited_again = true
-        localization_key.save! if localization_key.changed?
-      end
+      localization_key.is_visited_again = true if localization_key.is_deleted?
+      localization_key.save! if localization_key.changed?
       localization_keys[key_without_locale] = localization_key.id
       localization_key
     end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -311,8 +311,10 @@ module Lit
       localization_key = Lit::LocalizationKey.find_or_initialize_by(
         localization_key: key_without_locale
       )
-      localization_key.is_deleted = false
-      localization_key.save! if localization_key.changed?
+      if localization_key.is_deleted?
+        localization_key.is_visited_again = true
+        localization_key.save! if localization_key.changed?
+      end
       localization_keys[key_without_locale] = localization_key.id
       localization_key
     end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -308,9 +308,11 @@ module Lit
     end
 
     def find_or_create_localization_key(key_without_locale)
-      localization_key = Lit::LocalizationKey.find_or_create_by!(
+      localization_key = Lit::LocalizationKey.find_by(
         localization_key: key_without_locale
       )
+      localization_key.is_deleted = false
+      localization_key.save!
       localization_keys[key_without_locale] = localization_key.id
       localization_key
     end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -308,11 +308,11 @@ module Lit
     end
 
     def find_or_create_localization_key(key_without_locale)
-      localization_key = Lit::LocalizationKey.find_by(
+      localization_key = Lit::LocalizationKey.find_or_initialize_by(
         localization_key: key_without_locale
       )
       localization_key.is_deleted = false
-      localization_key.save!
+      localization_key.save! if localization_key.changed?
       localization_keys[key_without_locale] = localization_key.id
       localization_key
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018075955) do
+ActiveRecord::Schema.define(version: 20181030111522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20181018075955) do
     t.boolean  "is_completed",                 default: false
     t.boolean  "is_starred",                   default: false
     t.boolean  "is_deleted",                   default: false, null: false
+    t.boolean  "is_visited_again",             default: false, null: false
   end
 
   add_index "lit_localization_keys", ["localization_key"], name: "index_lit_localization_keys_on_localization_key", unique: true, using: :btree

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180101010109) do
+ActiveRecord::Schema.define(version: 20181018075955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,12 +39,13 @@ ActiveRecord::Schema.define(version: 20180101010109) do
     t.integer  "locale_id"
     t.integer  "localization_key_id"
     t.integer  "localization_id"
-    t.string   "locale_str",           limit: 255
-    t.string   "localization_key_str", limit: 255
+    t.string   "locale_str",                  limit: 255
+    t.string   "localization_key_str",        limit: 255
     t.integer  "source_id"
     t.integer  "incomming_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "localization_key_is_deleted",             default: false, null: false
   end
 
   add_index "lit_incomming_localizations", ["incomming_id"], name: "index_lit_incomming_localizations_on_incomming_id", using: :btree
@@ -66,6 +67,7 @@ ActiveRecord::Schema.define(version: 20180101010109) do
     t.datetime "updated_at"
     t.boolean  "is_completed",                 default: false
     t.boolean  "is_starred",                   default: false
+    t.boolean  "is_deleted",                   default: false, null: false
   end
 
   add_index "lit_localization_keys", ["localization_key"], name: "index_lit_localization_keys_on_localization_key", unique: true, using: :btree

--- a/test/functional/lit/localization_keys_controller_test.rb
+++ b/test/functional/lit/localization_keys_controller_test.rb
@@ -29,7 +29,7 @@ module Lit
     # Lit.loader.cache is a fresh object.
 
     # DELETE /localization_keys/:id
-    test 'should destroy localization key when Lit.loader.cache is fresh object' do
+    test 'should set is_deleted flag of localization key when Lit.loader.cache is fresh object' do
       with_fresh_cache do
         if new_controller_test_format?
           delete :destroy, params: { id: @localization_key.id, format: :js }
@@ -38,8 +38,8 @@ module Lit
         end
 
         assert_response :success
-        assert assigns(:localization_key).destroyed?
-        assert Lit::LocalizationKey.where(id: @localization_key.id).first.nil?
+        assert assigns(:localization_key).is_deleted
+        assert Lit::LocalizationKey.active.find_by(id: @localization_key.id).blank?
         assert !Lit.init.cache.has_key?("#{I18n.locale}.#{@localization_key.localization_key}")
       end
     end

--- a/test/functional/lit/localization_keys_controller_test.rb
+++ b/test/functional/lit/localization_keys_controller_test.rb
@@ -80,6 +80,18 @@ module Lit
       assert @localization_key.reload.is_completed
     end
 
+    # PUT /localization_keys/:id/restore_deleted
+    test 'should restore localization key' do
+      @localization_key.update is_deleted: true
+      if new_controller_test_format?
+        put :restore_deleted, params: { id: @localization_key.id }, format: :js
+      else
+        put :restore_deleted, id: @localization_key.id, format: :js
+      end
+      assert_response :success
+      assert_not @localization_key.reload.is_deleted
+    end
+
     private
 
     def with_fresh_cache

--- a/test/unit/lit/incomming_localization_test.rb
+++ b/test/unit/lit/incomming_localization_test.rb
@@ -6,23 +6,19 @@ module Lit
       DatabaseCleaner.clean_with :truncation
       stub_request(:get, 'http://testhost.com/lit/api/v1/last_change.json').
         to_return(body: { last_change: 1.hour.ago.to_s(:db) }.to_json)
-      @source = Lit::Source.new
-      @source.url = 'http://testhost.com/lit'
-      @source.api_key = 'test'
-      @source.identifier = 'test'
-      @source.save!
+      @source = Lit::Source.create url: 'http://testhost.com/lit',
+                                   api_key: 'test',
+                                   identifier: 'test'
     end
 
     test 'on accept deletes itself and creates all missing records' do
       assert_equal 0, Locale.count
       assert_equal 0, Localization.count
       assert_equal 0, LocalizationKey.count
-      il = IncommingLocalization.new
-      il.locale_str = 'de'
-      il.localization_key_str = 'scope.test'
-      il.translated_value = 'test'
-      il.source = @source
-      il.save!
+      il = IncommingLocalization.create locale_str: 'de',
+                                        localization_key_str: 'scope.test',
+                                        translated_value: 'scope.test',
+                                        source: @source
       assert_equal 0, Locale.count
       assert_equal 0, Localization.count
       assert_equal 0, LocalizationKey.count
@@ -31,6 +27,20 @@ module Lit
       assert_equal 1, Localization.count
       assert_equal 1, LocalizationKey.count
       assert_equal true, Localization.first.is_changed?
+    end
+
+    test '#duplicated? returns true when localization key is deleted' do
+      locale = Locale.create locale: 'en'
+      l_k = LocalizationKey.create localization_key: 'test'
+      localization = Localization.create locale: locale, localization_key: l_k,
+                                         translated_value: 'test test'
+      il = IncommingLocalization.create locale_str: locale.locale,
+                                        localization_key_str: l_k.localization_key,
+                                        translated_value: localization.translated_value,
+                                        localization: localization,
+                                        source: @source,
+                                        localization_key_is_deleted: true
+      assert_not il.duplicated?('test test')
     end
   end
 end

--- a/test/unit/lit/localization_key_test.rb
+++ b/test/unit/lit/localization_key_test.rb
@@ -35,5 +35,26 @@ module Lit
       assert @loc1.reload.is_changed
       assert @loc2.reload.is_changed
     end
+
+    test '#soft_destroy should mark translation key as deleted and translations as completed' do
+      assert_not @lk.is_completed
+      assert_not @loc1.is_changed
+      assert_not @loc2.is_changed
+      @lk.soft_destroy
+      assert @lk.reload.is_deleted
+      assert @lk.localizations.all?(&:is_changed)
+    end
+
+    test '#restore should restore translation key' do
+      @lk.change_all_completed
+      @lk.update is_deleted: true, is_visited_again: true
+      assert @lk.is_deleted
+      assert @lk.is_completed
+      assert @lk.is_visited_again
+      @lk.restore
+      assert_not @lk.is_deleted
+      assert_not @lk.is_completed
+      assert_not @lk.is_visited_again
+    end
   end
 end


### PR DESCRIPTION
Currently there is no support for synchronization of deleted records. This PR:
- marks `is_deleted` flag as true when deleting translation key via UI instead of destroying it,
- adds `is_deleted` as a part of synchronization process,
- deactivates localization key when its marked as `is_deleted`,
- activates localization key back when it's invoked via `I18n.t` again.