### PR TITLE
 Prevent from overwriting DB with nil defaults when redis gets cleared 

### DIFF
--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -204,7 +204,10 @@ module Lit
               value = fallback_to_default(localization_key, localization)
             end
           end
-          localization.update_default_value(value)
+          # Prevent overwriting existing default value with nil.
+          # However, if the localization record is #new_record?, we still need
+          # to insert it with an empty default value.
+          localization.update_default_value(value) if localization.new_record? || value
         end
         return localization
       end

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -207,6 +207,14 @@ class LitBehaviourTest < ActiveSupport::TestCase
     Lit.loader = old_loader
   end
 
+  test 'it does not overwrite values in DB with nil if default option is removed from I18n.t call after value is deleted from redis' do
+    I18n.t('foo', default: 'bar')
+    assert_equal 'bar', find_localization_for('foo', :en).value
+    $redis.flushdb # rubocop:disable Style/GlobalVars
+    I18n.t('foo')
+    assert_equal 'bar', find_localization_for('foo', :en).value
+  end
+
   private
 
   def find_localization_for(key, locale)

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -207,12 +207,14 @@ class LitBehaviourTest < ActiveSupport::TestCase
     Lit.loader = old_loader
   end
 
-  test 'it does not overwrite values in DB with nil if default option is removed from I18n.t call after value is deleted from redis' do
-    I18n.t('foo', default: 'bar')
-    assert_equal 'bar', find_localization_for('foo', :en).value
-    $redis.flushdb # rubocop:disable Style/GlobalVars
-    I18n.t('foo')
-    assert_equal 'bar', find_localization_for('foo', :en).value
+  if Lit.key_value_engine == 'redis'
+    test 'it does not overwrite values in DB with nil if default option is removed from I18n.t call after value is deleted from redis' do
+      I18n.t('foo', default: 'bar')
+      assert_equal 'bar', find_localization_for('foo', :en).value
+      $redis.flushdb # rubocop:disable Style/GlobalVars
+      I18n.t('foo')
+      assert_equal 'bar', find_localization_for('foo', :en).value
+    end
   end
 
   private


### PR DESCRIPTION
#79 

This ensures that - when Redis, for whatever reason, gets flushed - because of external manipulation or a Lit operation that performs it (it turns out that before #110 is merged in, it may happen during export because it uses `Lit.init.cache.clear`) - translations do not disappear from the database.