### PR TITLE
Introduce a list of keys to ignore for auto-humanize

### DIFF
--- a/lib/lit.rb
+++ b/lib/lit.rb
@@ -8,6 +8,8 @@ module Lit
   mattr_accessor :redis_url
   mattr_accessor :storage_options
   mattr_accessor :humanize_key
+  mattr_accessor :humanize_key_ignored_keys
+  mattr_accessor :humanize_key_ignored
   mattr_accessor :ignored_keys
   mattr_accessor :ignore_yaml_on_startup
   mattr_accessor :api_enabled
@@ -25,6 +27,10 @@ module Lit
     if loader.nil? && @@table_exists
       self.loader ||= Loader.new
       Lit.humanize_key = false if Lit.humanize_key.nil?
+      Lit.humanize_key_ignored_keys = [] if Lit.humanize_key_ignored_keys.nil?
+      Lit.humanize_key_ignored = %w[i18n date datetime number time support ]
+      Lit.humanize_key_ignored |= Lit.humanize_key_ignored_keys
+      Lit.humanize_key_ignored = %r{(#{Lit.humanize_key_ignored.join('|')}).*}
       if Lit.ignored_keys.is_a?(String)
         keys = Lit.ignored_keys.split(',').map(&:strip)
         Lit.ignored_keys = keys

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -108,7 +108,7 @@ module Lit
           # it anyway if we return nil, but then it will wrap it also in
           # translation_missing span.
           # Humanizing key should be last resort
-          if content.nil? && Lit.humanize_key
+          if content.nil? && Lit.humanize_key && !key.match?(Lit.humanize_key_ignored)
             content = key.to_s.split('.').last.humanize
             if content.present?
               @cache[key_with_locale] = content

--- a/test/unit/i18n_backend_test.rb
+++ b/test/unit/i18n_backend_test.rb
@@ -7,12 +7,17 @@ class I18nBackendTest < ActiveSupport::TestCase
 
   def setup
     @old_backend = I18n.backend
+    @old_locale = I18n.locale
+    @old_humanize_key = Lit.humanize_key
     @old_available_locales = ::Rails.configuration.i18n.available_locales
   end
 
   def teardown
     ::Rails.configuration.i18n.available_locales = @old_available_locales
     I18n.backend = @old_backend
+    I18n.backend = @old_backend
+    I18n.locale = @old_locale
+    Lit.humanize_key = @old_humanize_key
   end
 
   test 'properly returns available locales' do
@@ -24,5 +29,28 @@ class I18nBackendTest < ActiveSupport::TestCase
     ::Rails.configuration.i18n.available_locales = [:en]
     I18n.backend = Backend.new(Lit.loader.cache)
     assert_equal 1, I18n.backend.available_locales.count
+  end
+
+  test 'auto-humanizes key when Lit.humanize_key=true' do
+    Lit.humanize_key = true
+    I18n.locale = :en
+    test_key = 'this_will_get_humanized'
+    humanized_key = 'This will get humanized'
+    assert_equal I18n.t(test_key), humanized_key
+    lk = Lit::LocalizationKey.find_by localization_key: test_key
+    locale = Lit::Locale.find_by locale: 'en'
+    l = lk.localizations.where(locale: locale).first
+    assert_equal l.default_value, humanized_key
+  end
+
+  test 'wont humanize key, if key is ignored' do
+    Lit.humanize_key = true
+    I18n.locale = :en
+    test_key = 'date.this_will_get_humanized'
+    assert_equal I18n.t(test_key), 'translation missing: en.date.this_will_get_humanized'
+    lk = Lit::LocalizationKey.find_by localization_key: test_key
+    locale = Lit::Locale.find_by locale: 'en'
+    l = lk.localizations.where(locale: locale).first
+    assert_nil l.default_value
   end
 end


### PR DESCRIPTION
`Lit.humanize_key = true` makes a lot of mess trying to auto-humanize too much. This introduces concept of key prefixes, that will always be ignored, when this setting is turned on.