### PR TITLE
Fix is_changed not being set correctly on localization edit via UI

### DIFF
--- a/app/controllers/lit/localizations_controller.rb
+++ b/app/controllers/lit/localizations_controller.rb
@@ -15,7 +15,13 @@ module Lit
     end
 
     def update
-      after_update_operations if @localization.update_attributes(clear_params)
+      # Wrapping it in a transaction leverages the fact that @localization's
+      # :after_commit callback is then executed AFTER whatever's done in
+      # #after_update_operations. So it'll first set :is_changed to true
+      # and then it will be properly read in the cache setting routine.
+      @localization.transaction do
+        after_update_operations if @localization.update_attributes(clear_params)
+      end
       respond_to do |f|
         f.js
         f.json do

--- a/test/functional/lit/localizations_controller_test.rb
+++ b/test/functional/lit/localizations_controller_test.rb
@@ -141,6 +141,12 @@ module Lit
       assert_response :success
       @localization.reload
       assert_equal true, @localization.is_changed?
+      # test that the new value has also been cached
+      assert(
+        Lit.init.cache[
+          'en.' + @localization.localization_key.localization_key
+        ] == 'new-value'
+      )
     end
 
     # PUT /localization_keys/:localization_key_id/localizations/:id/change_completed


### PR DESCRIPTION
Recently, a glitch has surfaced which caused the UI to require two localization value submits (separated by a page refresh) for the localization to be actually submitted.

The root cause was that the `is_changed` flag was being set at a step later than it should have been, so the value that appeared in cache was not the translated value, but the default value (while in the database the translated value was inserted correctly).

The fix includes an explanatory comment.