### PR TITLE
Storing localizations even after rollback

### DIFF
--- a/app/models/lit/base.rb
+++ b/app/models/lit/base.rb
@@ -1,0 +1,41 @@
+class Lit::Base < ActiveRecord::Base
+  self.abstract_class = true
+
+  before_save :mark_for_retry_on_create, on: :create
+  before_save :mark_for_retry_on_update, on: :update
+
+  def mark_for_retry_on_create
+    @will_retry_create = true
+  end
+
+  def mark_for_retry_on_update
+    @will_retry_update = true
+  end
+
+
+  after_rollback :retry_lit_model_save
+
+  private
+
+  def retry_lit_model_save
+    retry_on_create if @will_retry_create
+    retry_on_update if @will_retry_update
+  end
+
+  def retry_on_create
+    return if @retry_created
+    @retry_created = true
+    self.class.create attributes
+  end
+
+  def retry_on_update
+    return if @retry_updated
+    @retry_updated = true
+    update attributes
+  end
+
+  def lit_attribute_will_change
+    raise NotImplementedErrror
+  end
+
+end

--- a/app/models/lit/base.rb
+++ b/app/models/lit/base.rb
@@ -32,7 +32,7 @@ class Lit::Base < ActiveRecord::Base
   def retry_on_update
     return if self.retried_updated
     self.retried_updated = true
-    update attributes.merge(retried_updated: true)
+    update! attributes.merge(retried_updated: true)
   end
 
 end

--- a/app/models/lit/locale.rb
+++ b/app/models/lit/locale.rb
@@ -1,5 +1,5 @@
 module Lit
-  class Locale < ActiveRecord::Base
+  class Locale < Base
     ## SCOPES
     scope :ordered, -> { order(locale: :asc) }
     scope :visible, -> { where(is_hidden: false) }

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -50,8 +50,7 @@ module Lit
     end
 
     def translation
-      #is_changed? && !translated_value.nil? ? translated_value : default_value
-      translated_value.nil? ? default_value : translated_value
+      is_changed? && !translated_value.nil? ? translated_value : default_value
     end
 
     def value
@@ -76,7 +75,6 @@ module Lit
 
     def update_default_value(value)
       return true if persisted? && default_value == value
-
       if persisted?
         update(default_value: value)
       else

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -29,6 +29,8 @@ module Lit
     validates :locale, :localization_key, presence: true
 
     ## ACCESSORS
+    attr_accessor :full_key_str
+
     unless defined?(::ActionController::StrongParameters)
       attr_accessible :translated_value, :locale_id
     end
@@ -44,11 +46,12 @@ module Lit
     end
 
     def full_key
-      [locale.locale, localization_key.localization_key].join('.')
+      full_key_str || [locale.locale, localization_key.localization_key].join('.')
     end
 
     def translation
-      is_changed? && !translated_value.nil? ? translated_value : default_value
+      #is_changed? && !translated_value.nil? ? translated_value : default_value
+      translated_value.nil? ? default_value : translated_value
     end
 
     def value
@@ -73,6 +76,7 @@ module Lit
 
     def update_default_value(value)
       return true if persisted? && default_value == value
+
       if persisted?
         update(default_value: value)
       else

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -1,5 +1,5 @@
 module Lit
-  class Localization < ActiveRecord::Base
+  class Localization < Lit::Base
     serialize :translated_value
     serialize :default_value
 
@@ -74,7 +74,7 @@ module Lit
     def update_default_value(value)
       return true if persisted? && default_value == value
       if persisted?
-        update_column(:default_value, value)
+        update(default_value: value)
       else
         self.default_value = value
         save!
@@ -92,5 +92,6 @@ module Lit
       translated_value = translated_value_was || default_value
       localization_versions.new(translated_value: translated_value)
     end
+
   end
 end

--- a/app/models/lit/localization.rb
+++ b/app/models/lit/localization.rb
@@ -26,7 +26,7 @@ module Lit
     delegate :is_deleted, to: :localization_key
 
     ## VALIDATIONS
-    validates :locale, presence: true
+    validates :locale, :localization_key, presence: true
 
     ## ACCESSORS
     unless defined?(::ActionController::StrongParameters)

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -187,6 +187,9 @@ module Lit
           # Prevent overwriting existing default value with nil.
           # However, if the localization record is #new_record?, we still need
           # to insert it with an empty default value.
+          localization.locale = locale
+          localization.localization_key = localization_key
+          localization.full_key_str = full_key
           localization.update_default_value(value) if localization.new_record? || value
           @localization_object_cache[full_key] = localization
         end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -81,6 +81,8 @@ module Lit
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
       delete_localization(locale, key_without_locale)
+      @localization_key_object_cache = {}
+      @localization_object_cache = {}
     end
 
     def load_all_translations
@@ -98,6 +100,7 @@ module Lit
       key = key.to_s
       locale_key, key_without_locale = split_key(key)
       locale = find_locale(locale_key)
+      @localization_object_cache.delete(key)
       localization = find_localization(locale, key_without_locale, default_fallback: true)
       localizations[key] = localization.translation if localization
     end
@@ -107,11 +110,15 @@ module Lit
       localizations.delete(key)
       key_without_locale = split_key(key).last
       localization_keys.delete(key_without_locale)
+      @localization_object_cache.delete(key)
+      @localization_key_object_cache.delete(key)
       I18n.backend.reload!
     end
 
     def reset
       @locale_cache = {}
+      @localization_key_object_cache = {}
+      @localization_object_cache = {}
       localizations.clear
       localization_keys.clear
       load_all_translations

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -123,8 +123,8 @@ module Lit
       key = ([locale] + scope).join('.')
       if data.respond_to?(:to_hash)
         # ActiveRecord::Base.transaction do
-          data.to_hash.each do |key, value|
-            store_item(locale, value, scope + [key], startup_process)
+          data.to_hash.each do |k, value|
+            store_item(locale, value, scope + [k], startup_process)
           end
         # end
       elsif data.respond_to?(:to_str) || data.is_a?(Array)

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -69,11 +69,9 @@ module Lit
 
       parts = I18n.normalize_keys(locale, key, scope, options[:separator])
       key_with_locale = parts.join('.')
-
       # check in cache or in simple backend
       content = @cache[key_with_locale] || super
       return content if parts.size <= 1
-
       if content.nil? && should_cache?(key_with_locale, options)
         new_content = @cache.init_key_with_value(key_with_locale, content)
         content = new_content if content.nil? # Content can change when Lit.humanize is true for example

--- a/test/dummy/app/controllers/projects_controller.rb
+++ b/test/dummy/app/controllers/projects_controller.rb
@@ -84,10 +84,6 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    if defined?(::ActionController::StrongParameters)
-      params.require(:project).permit(:name)
-    else
-      params
-    end
+    params.require(:project).permit(:name)
   end
 end

--- a/test/dummy/app/controllers/projects_controller.rb
+++ b/test/dummy/app/controllers/projects_controller.rb
@@ -44,7 +44,7 @@ class ProjectsController < ApplicationController
 
     respond_to do |format|
       if @project.save
-        format.html { redirect_to @project, notice: 'Project was successfully created.' }
+        format.html { redirect_to project_path(@project, locale: I18n.locale), notice: 'Project was successfully created.' }
         format.json { render json: @project, status: :created, location: @project }
       else
         format.html { render action: 'new' }

--- a/test/dummy/app/models/project.rb
+++ b/test/dummy/app/models/project.rb
@@ -1,7 +1,5 @@
 class Project < ActiveRecord::Base
-  unless defined?(::ActionController::StrongParameters)
-    attr_accessible :name
-  end
+
   validates_presence_of :name
 
 end

--- a/test/dummy/app/models/project.rb
+++ b/test/dummy/app/models/project.rb
@@ -2,4 +2,6 @@ class Project < ActiveRecord::Base
   unless defined?(::ActionController::StrongParameters)
     attr_accessible :name
   end
+  validates_presence_of :name
+
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,4 @@
-# This file is auto-generated from the current state of the database. Instead
+#, on: :update This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,4 @@
-#, on: :update This file is auto-generated from the current state of the database. Instead
+# This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #

--- a/test/integration/lit/projects_test.rb
+++ b/test/integration/lit/projects_test.rb
@@ -20,7 +20,11 @@ class ProjectsTest < ActionDispatch::IntegrationTest
   end
 
   test 'should have error messages' do
-    post '/en/projects', params: { project: { name: '' } }
+    if ::Rails::VERSION::MAJOR < 5
+      post '/en/projects', project: { name: '' }
+    else
+      post '/en/projects', params: { project: { name: '' } }
+    end
     locale = Lit::Locale.where('locale=?', 'en').first
     localization_key = Lit::LocalizationKey.find_by_localization_key! 'activerecord.errors.models.project.attributes.name.blank'
     localization = localization_key.localizations.where(locale_id: locale.id).first
@@ -30,7 +34,11 @@ class ProjectsTest < ActionDispatch::IntegrationTest
 
   test 'should have error message humanized' do
     Lit.humanize_key = true
-    post '/en/projects', params: { project: { name: '' } }
+    if ::Rails::VERSION::MAJOR < 5
+      post '/en/projects', project: { name: '' }
+    else
+      post '/en/projects', params: { project: { name: '' } }
+    end
     locale = Lit::Locale.where('locale=?', 'en').first
     localization_key = Lit::LocalizationKey.find_by_localization_key! 'activerecord.errors.models.project.attributes.name.blank'
     localization = localization_key.localizations.where(locale_id: locale.id).first

--- a/test/integration/lit/projects_test.rb
+++ b/test/integration/lit/projects_test.rb
@@ -4,18 +4,37 @@ require 'test_helper'
 class ProjectsTest < ActionDispatch::IntegrationTest
   setup do
     @old = Lit.humanize_key
-    Lit.humanize_key = true
   end
   teardown do
     Lit.humanize_key = @old
   end
 
   test 'should display translated project name' do
+    Lit.humanize_key = true
     visit('/en/projects/new')
     locale = Lit::Locale.where('locale=?', 'en').first
     localization_key = Lit::LocalizationKey.find_by_localization_key! 'helpers.label.project.name'
     localization = localization_key.localizations.where(locale_id: locale.id).first
     assert_equal 'Name', localization.to_s
     assert_equal 'Name', localization.default_value
+  end
+
+  test 'should have error messages' do
+    post '/en/projects', params: { project: { name: '' } }
+    locale = Lit::Locale.where('locale=?', 'en').first
+    localization_key = Lit::LocalizationKey.find_by_localization_key! 'activerecord.errors.models.project.attributes.name.blank'
+    localization = localization_key.localizations.where(locale_id: locale.id).first
+    assert_nil localization.to_s
+    assert_nil localization.default_value
+  end
+
+  test 'should have error message humanized' do
+    Lit.humanize_key = true
+    post '/en/projects', params: { project: { name: '' } }
+    locale = Lit::Locale.where('locale=?', 'en').first
+    localization_key = Lit::LocalizationKey.find_by_localization_key! 'activerecord.errors.models.project.attributes.name.blank'
+    localization = localization_key.localizations.where(locale_id: locale.id).first
+    assert_equal 'Blank', localization.to_s
+    assert_equal 'Blank', localization.default_value
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ I18n.config.enforce_available_locales = false
 # Transactional fixtures do not work with Selenium tests, because Capybara
 # uses a separate server thread, which the transactions would be hidden
 # from. We hence use DatabaseCleaner to truncate our test database.
-DatabaseCleaner.strategy = :transaction
+DatabaseCleaner.strategy = :truncation
 
 DatabaseCleaner.clean_with :truncation
 
@@ -43,7 +43,7 @@ class ActiveSupport::TestCase
   include WebMock::API
 
   if respond_to?(:use_transactional_tests=)
-    self.use_transactional_tests = true
+    self.use_transactional_tests = false
   else
     self.use_transactional_fixtures = true
   end
@@ -79,7 +79,7 @@ class ActionDispatch::IntegrationTest
     DatabaseCleaner.clean       # Truncate the database
     Capybara.reset_sessions!    # Forget the (simulated) browser state
     Capybara.use_default_driver # Revert Capybara.current_driver to Capybara.default_driver
-    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.strategy = :truncation
   end
 end
 


### PR DESCRIPTION
Proof of concept of storing localizations even after rollback in parent form.

Two major things are happening here:
- we try to insert / update `LocalizationKey` / `Localization` even after rollback in parent transaction
- `Localization` and `LocalizationKey` instances are now memoized in `Lit::Cache` 

WIP - still requires tests, but I want to get initial opinion