### PR TITLE
Add INCLUDE_HITS_COUNT option to CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ $ rake lit:export FORMAT=csv LOCALES=en,pl OUTPUT=export.csv
 
 Using the task `lit:export_splitted` does the same as `lit:export` but splits the locales by their name (`config/locales/en.yml`, etc).
 
+Optionally, the `INCLUDE_HITS_COUNT` option (only applicable for CSV export) can be used to include current hits count for each localization key. Note that it only makes sense to use this option when Redis is Lit's key-value engine because these counters are stored in cache and not in the database.
+
 #### Import
 
 Translation import is handled using the `lit:import` task, where imported file name should be specified in the `FILE` envionment variable:

--- a/lib/tasks/lit_tasks.rake
+++ b/lib/tasks/lit_tasks.rake
@@ -3,9 +3,10 @@ namespace :lit do
   task export: :environment do
     locale_keys = ENV['LOCALES'].to_s.split(',') || []
     export_format = ENV['FORMAT'].presence&.downcase&.to_sym || :yaml
+    include_hits_count = ENV['INCLUDE_HITS_COUNT'].present?
     path = ENV['OUTPUT'].presence || Rails.root.join('config', 'locales', "lit.#{file_extension(export_format)}")
-
-    if exported = Lit::Export.call(locale_keys: locale_keys, format: export_format)
+    if exported = Lit::Export.call(locale_keys: locale_keys, format: export_format,
+                                   include_hits_count: include_hits_count)
       File.new(path, 'w').write(exported)
       puts "Successfully exported #{path}."
     end

--- a/test/unit/export_test.rb
+++ b/test/unit/export_test.rb
@@ -7,6 +7,8 @@ class ExportTest < ActiveSupport::TestCase
 
   def setup
     I18n.backend.reset_available_locales_cache
+    Lit.init.cache.instance_variable_get(:@hits_counter).clear
+    Lit.init.cache.instance_variable_get(:@hits_counter).clear
   end
 
   test 'exports all locales to yaml when locale keys not specified' do

--- a/test/unit/export_test.rb
+++ b/test/unit/export_test.rb
@@ -53,4 +53,14 @@ class ExportTest < ActiveSupport::TestCase
     parsed_csv = CSV.parse(csv)
     assert parsed_csv.map(&:first).exclude?('scopes.string')
   end
+
+  test 'includes hits count if specified' do
+    seen_lk = Lit::LocalizationKey.first
+    unseen_lk = Lit::LocalizationKey.second
+    10.times { I18n.t(seen_lk.localization_key) }
+    csv = Lit::Export.call(locale_keys: [], format: :csv, include_hits_count: true)
+    parsed_csv = CSV.parse(csv)
+    assert parsed_csv.find { |row| row.first == seen_lk.localization_key }.last.to_i == 10
+    assert parsed_csv.find { |row| row.first == unseen_lk.localization_key }.last.to_i == 0
+  end
 end


### PR DESCRIPTION
This option includes hits count for a given localization key as the last column in CSV export. It allows the file to be easily filtered using spreadsheet software.