### PR TITLE
Localization unique index

### DIFF
--- a/db/migrate/20181129103819_lit_add_localization_key_locale_unique_index_to_localizations.rb
+++ b/db/migrate/20181129103819_lit_add_localization_key_locale_unique_index_to_localizations.rb
@@ -1,0 +1,7 @@
+class LitAddLocalizationKeyLocaleUniqueIndexToLocalizations < Rails::VERSION::MAJOR >= 5   ?
+                                                              ActiveRecord::Migration[4.2] :
+                                                              ActiveRecord::Migration
+  def change
+    add_index :lit_localizations, [:localization_key_id, :locale_id], unique: true
+  end
+end

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -168,8 +168,7 @@ module Lit
         localization_key = find_localization_key(key_without_locale)
         localization = @localization_object_cache[full_key]
         localization ||=
-          Lit::Localization.active
-                           .where(locale_id: locale.id)
+          Lit::Localization.where(locale_id: locale.id)
                            .where(localization_key_id: localization_key.id)
                            .first_or_initialize
         if update_value || localization.new_record?

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -111,7 +111,7 @@ module Lit
       key_without_locale = split_key(key).last
       localization_keys.delete(key_without_locale)
       @localization_object_cache.delete(key)
-      @localization_key_object_cache.delete(key)
+      @localization_key_object_cache.delete(key_without_locale)
       I18n.backend.reload!
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_30_111522) do
+ActiveRecord::Schema.define(version: 2018_11_29_103819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2018_10_30_111522) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["locale_id"], name: "index_lit_localizations_on_locale_id"
+    t.index ["localization_key_id", "locale_id"], name: "index_lit_localizations_on_localization_key_id_and_locale_id", unique: true
     t.index ["localization_key_id"], name: "index_lit_localizations_on_localization_key_id"
   end
 

--- a/test/unit/lit/localization_key_test.rb
+++ b/test/unit/lit/localization_key_test.rb
@@ -45,6 +45,14 @@ module Lit
       assert @lk.localizations.all?(&:is_changed)
     end
 
+    test '#soft_destroy should delete translation key from memoized objects' do
+      lk_obj_cache = Lit.init.cache.instance_variable_get(:@localization_key_object_cache)
+      Lit.init.cache.refresh_key("en.#{@lk.localization_key}")
+      assert lk_obj_cache[@lk.localization_key] == @lk
+      @lk.soft_destroy
+      refute lk_obj_cache.key?(@lk.localization_key)
+    end
+
     test '#restore should restore translation key' do
       @lk.change_all_completed
       @lk.update is_deleted: true, is_visited_again: true

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -225,6 +225,15 @@ class LitBehaviourTest < ActiveSupport::TestCase
     end
   end
 
+  test 'it does not create duplicate db records when a previously deleted key appears again' do
+    loc_count = Lit::Localization.count
+    I18n.t('foo', default: 'bar')
+    assert Lit::Localization.count == loc_count + 1
+    Lit::LocalizationKey.find_by(localization_key: 'foo').soft_destroy
+    I18n.t('foo', default: 'baz')
+    assert Lit::Localization.count == loc_count + 1
+  end
+
   private
 
   def find_localization_for(key, locale)


### PR DESCRIPTION
This fixes errors caused by the fact that we didn't have unique indexes on `locale_id, localization_key_id` in `lit_localizations`. This should fix the most important issue which arose after "soft deletion" of keys.

Some work on handling edge cases (e.g. rare cases of duplicate `Lit::LocalizationKey` insertion in concurrent requests) is still in progress... I've been trying to find a solution that plays nicely with both PostgreSQL and MySQL and is well-behaving with our recently-added retry scheme, which is non-trivial to say the least.