### PR TITLE
Test updates, pt. 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test/dummy/.sass-cache
 .sass-cache/
 /lit-*.gem
 **.DS_Store
+Gemfile.lock
 vendor/bundle
 /tags
 test/dummy/config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ translating app by non-technicals.
 
 Highly inspired by Copycopter by thoughtbot.
 
-![travis status](https://travis-ci.org/prograils/lit.svg)
+[![travis status](https://travis-ci.org/prograils/lit.svg)](https://travis-ci.org/prograils/lit)
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ Lit.store_request_info = true
 
 ### Testing
 
-1. gem install bundler appraisal # Install some gems
-2. appraisal install              # install gems from appraisal's gemfiles
-3. cp test/dummy/config/database.yml.sample test/dummy/config/database.yml # move a database.yml in place
-4. RAILS_ENV=test appraisal rails-4.2 rake db:setup # setup lit DB (see test/config/database.yml)
-5. appraisal rake # run the tests!
+1. `gem install bundler && bundle install` - ensure Bundler and all required gems are installed
+2. `bundle exec appraisal install` - install gems from appraisal's gemfiles
+3. `cp test/dummy/config/database.yml.sample test/dummy/config/database.yml` - move a database.yml in place (remember to fill your DB credentials in it)
+4. `RAILS_ENV=test appraisal rails-5.2 rake db:setup` - setup lit DB (see test/config/database.yml); do it only once, it does not matter which Rails version you use for `appraisal`
+5. `bundle exec appraisal rake` - run the tests!
 
 ### License
 

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -16,3 +16,5 @@ gem "jquery-rails"
 gem "coffee-rails"
 gem "pry-rails"
 gem "test_after_commit"
+
+gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ..
+  specs:
+    lit (0.4.0.pre.alpha.4)
+      coffee-rails
+      jquery-rails
+      rails (>= 4.2.0)
+      sass-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -37,6 +46,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
     arel (6.0.4)
     bcrypt (3.1.12)
     builder (3.2.3)
@@ -177,11 +190,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appraisal (~> 2.2.0)
   capybara
   coffee-rails
   database_cleaner
   devise
   jquery-rails
+  lit!
   mocha
   pg (~> 0.18.4)
   pry-rails

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -17,3 +17,5 @@ gem "coffee-rails"
 gem "pry-rails"
 gem "rails-controller-testing"
 gem "minitest", "~> 5.10"
+
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ..
+  specs:
+    lit (0.4.0.pre.alpha.4)
+      coffee-rails
+      jquery-rails
+      rails (>= 4.2.0)
+      sass-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,6 +49,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
     arel (7.1.4)
     bcrypt (3.1.12)
     builder (3.2.3)
@@ -185,11 +198,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appraisal (~> 2.2.0)
   capybara
   coffee-rails
   database_cleaner
   devise
   jquery-rails
+  lit!
   minitest (~> 5.10)
   mocha
   pg (~> 0.21.0)

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -17,3 +17,5 @@ gem "coffee-rails"
 gem "pry-rails"
 gem "rails-controller-testing"
 gem "minitest"
+
+gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ..
+  specs:
+    lit (0.4.0.pre.alpha.4)
+      coffee-rails
+      jquery-rails
+      rails (>= 4.2.0)
+      sass-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,6 +49,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
     arel (8.0.0)
     bcrypt (3.1.12)
     builder (3.2.3)
@@ -185,11 +198,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appraisal (~> 2.2.0)
   capybara
   coffee-rails
   database_cleaner
   devise
   jquery-rails
+  lit!
   minitest
   mocha
   pg (~> 0.21.0)

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -17,3 +17,5 @@ gem "coffee-rails"
 gem "pry-rails"
 gem "rails-controller-testing"
 gem "minitest"
+
+gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ..
+  specs:
+    lit (0.4.0.pre.alpha.4)
+      coffee-rails
+      jquery-rails
+      rails (>= 4.2.0)
+      sass-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -44,6 +53,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
     arel (9.0.0)
     bcrypt (3.1.12)
     builder (3.2.3)
@@ -193,11 +206,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appraisal (~> 2.2.0)
   capybara
   coffee-rails
   database_cleaner
   devise
   jquery-rails
+  lit!
   minitest
   mocha
   pg (~> 1.1.3)

--- a/lib/lit/loader.rb
+++ b/lib/lit/loader.rb
@@ -10,7 +10,7 @@ module Lit
     attr_accessor :logger
     def initialize
       self.logger ||= Logger.new($stdout)
-      self.logger.info 'initializing Lit'
+      self.logger.info 'initializing Lit' unless ::Rails.env.test?
       self.cache ||= Cache.new
       I18n.backend = I18nBackend.new(self.cache)
     end

--- a/lit.gemspec
+++ b/lit.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'sass-rails'
+  s.add_development_dependency 'appraisal', '~> 2.2.0'
 end
 

--- a/test/dummy/config/database.yml.sample
+++ b/test/dummy/config/database.yml.sample
@@ -1,26 +1,11 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
-
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   adapter: postgresql
   database: lit_test
+  username:
+  password:
   host: localhost
-  pool: 5
-  timeout: 5000
-
-production:
-  adapter: sqlite3
-  database: db/production.sqlite3
   pool: 5
   timeout: 5000

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
+# We get a whole bunch of method redefinition warnings, mostly coming
+# from Devise - e.g. when routes are reloaded in controller tests.
+# That's not ideal but we don't need those. (Funny enough, default `$VERBOSE`
+# when using `rails test` instead of `rake` is `false`)
+$VERBOSE = false # equivalent to `ruby -W1`
+
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rails/test_help'
 require 'capybara/rails'


### PR DESCRIPTION
Follow-up to #120. The setup steps in README.md are changed slightly, in accordance with the fact that a `Gemfile` has now been checked into the repository - hence, `bundle exec` can be used for any Appraisal-related command. As well as that, test log clutter has been reduced.