### PR TITLE
Fix/array nil import and cloud translation

### DIFF
--- a/lib/lit/cloud_translation/providers/google.rb
+++ b/lib/lit/cloud_translation/providers/google.rb
@@ -96,6 +96,8 @@ module Lit::CloudTranslation::Providers
         text_or_array.gsub(/%{(.+?)}/, '<code>__LIT__\1__LIT__</code>')
       when Array
         text_or_array.map { |s| sanitize_text(s) }
+      when nil
+        ''
       else
         raise TypeError
       end

--- a/lib/lit/cloud_translation/providers/yandex.rb
+++ b/lib/lit/cloud_translation/providers/yandex.rb
@@ -63,6 +63,8 @@ module Lit::CloudTranslation::Providers
         text_or_array.gsub(/%{(.+?)}/, '%{_LIT_\1_LIT_}')
       when Array
         text_or_array.map { |s| sanitize_text(s) }
+      when nil
+        ''
       else
         raise TypeError
       end

--- a/lib/lit/import.rb
+++ b/lib/lit/import.rb
@@ -158,7 +158,7 @@ module Lit
             accu[-1] = [
               row.first,
               *accu[-1].drop(1)
-                       .map { |x| Array.wrap(x) }
+                       .map { |x| Array.wrap(x).presence || [x] }
                        .zip(row.drop(1)).map(&:flatten)
             ]
           end

--- a/test/cassettes/Lit_CloudTranslation_Providers_Google/when_only_to_language_is_given/when_array_containing_nil_values_is_given/translates_array_to_target_language_converting_nil_to_.yml
+++ b/test/cassettes/Lit_CloudTranslation_Providers_Google/when_only_to_language_is_given/when_array_containing_nil_values_is_given/translates_array_to_target_language_converting_nil_to_.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://translation.googleapis.com/language/translate/v2
+    body:
+      encoding: UTF-8
+      string: '{"q":["","awesome","","stuff"],"target":"pl"}'
+    headers:
+      User-Agent:
+      - gcloud-ruby/1.2.4
+      Google-Cloud-Resource-Prefix:
+      - projects/litbox-1543326618593
+      Content-Type:
+      - application/json
+      X-Goog-Api-Client:
+      - gl-ruby/2.5.0 gccl/1.2.4
+      Authorization:
+      - Bearer ya29.c.ElqNBtONxO3sNT5T1-qtaQE-6ImjJjwhffIA7KXaSjBMnSdZ_neeFTtirJwglYCuOmADQ42p8aA6cdR6r42wJT1B6ODQCQxKBRGEv86NdU58YY0egDnyUxc8i1w
+      Cache-Control:
+      - no-store
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Thu, 10 Jan 2019 13:47:15 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "data": {
+            "translations": [
+              {
+                "translatedText": "",
+                "detectedSourceLanguage": "en"
+              },
+              {
+                "translatedText": "niesamowite",
+                "detectedSourceLanguage": "en"
+              },
+              {
+                "translatedText": "",
+                "detectedSourceLanguage": "en"
+              },
+              {
+                "translatedText": "rzeczy",
+                "detectedSourceLanguage": "en"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 10 Jan 2019 13:47:15 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/Lit_CloudTranslation_Providers_Google/when_only_to_language_is_given/when_array_of_strings_is_given/translates_array_of_strings_to_target_language.yml
+++ b/test/cassettes/Lit_CloudTranslation_Providers_Google/when_only_to_language_is_given/when_array_of_strings_is_given/translates_array_of_strings_to_target_language.yml
@@ -67,6 +67,58 @@ http_interactions:
             ]
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 14 Dec 2018 11:07:06 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJzdGFydGluZy1hY2NvdW50LXViczN0amkwdW81YUBsaXRib3gtMTU0MzMyNjYxODU5My5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImF1ZCI6Imh0dHBzOi8vb2F1dGgyLmdvb2dsZWFwaXMuY29tL3Rva2VuIiwiZXhwIjoxNTQ3MTI4MDk1LCJpYXQiOjE1NDcxMjc5NzUsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9jbG91ZC1wbGF0Zm9ybSJ9.lnCmsIS61sxoZjFbVsYSwNic-6y3dCAwVv6UnXfvQAujmwcRL-UTC56dDa8zwVYd-RaCfLKhRWg337e0xoM6HT79RjBOPpj8kdBajRLgcruj0w9XNcvQ3dFyJifps4hMxCe9cTpjulexQDVJD_p2bhQO5mU9r4-FSxL36oz5rcc0aJGT8Dr4PP7mk9cJ2PI1zzHEc36QjhwkycrEuJOtJgAY-USSUEYjFDwK6zJzxPiPHOhRkGuDHBSPFcDyOB6rIZ5mLol96-QxjB__oWatRGnmQOxOHtX-P2x__svrYUYHJ-Ms6CaUv9yK9LAiaWB7ppMTCr4JlZPYARfeY5hV5g
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Thu, 10 Jan 2019 13:47:15 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "ya29.c.ElqNBtONxO3sNT5T1-qtaQE-6ImjJjwhffIA7KXaSjBMnSdZ_neeFTtirJwglYCuOmADQ42p8aA6cdR6r42wJT1B6ODQCQxKBRGEv86NdU58YY0egDnyUxc8i1w",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Jan 2019 13:47:15 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/Lit_CloudTranslation_Providers_Yandex/when_only_to_language_is_given/when_array_containing_nil_values_is_given/translates_array_to_target_language_converting_nil_to_.yml
+++ b/test/cassettes/Lit_CloudTranslation_Providers_Yandex/when_only_to_language_is_given/when_array_containing_nil_values_is_given/translates_array_to_target_language_converting_nil_to_.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://translate.yandex.net/api/v1.5/tr.json/translate?key=trnsl.1.1.20181127T145246Z.3e17e5c99c1ad299.38126a1782dbe6e5fa5a3d91c9789cfb178a0d78&lang=pl&text=stuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - translate.yandex.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Thu, 10 Jan 2019 13:44:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=120
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-store
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"lang":"en-pl","text":["","niesamowite","","rzeczy"]}'
+    http_version: 
+  recorded_at: Thu, 10 Jan 2019 13:44:43 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/lit/files/import.csv.array_with_nil
+++ b/test/fixtures/lit/files/import.csv.array_with_nil
@@ -1,0 +1,6 @@
+key,en,pl
+scopes.csvarray,,
+scopes.csvarray,val0 en,"val0 pl"
+scopes.csvarray,val1 en,"val1 pl"
+scopes.csvarray,,"val2 pl"
+scopes.csvarray,val3 en,

--- a/test/unit/lit/cloud_translation/providers/examples.rb
+++ b/test/unit/lit/cloud_translation/providers/examples.rb
@@ -32,6 +32,18 @@ def cloud_provider_examples(described_klass)
         subject.length.must_equal 2
       end
     end
+
+    describe 'when array containing nil values is given' do
+      let(:text) { [nil, 'awesome', nil, 'stuff'] }
+
+      it 'translates array to target language, converting nil to ""' do
+        subject.first.must_equal ''
+        subject.second.must_be :present?
+        subject.third.must_equal ''
+        subject.fourth.must_be :present?
+        subject.length.must_equal 4
+      end
+    end
   end
 
   describe 'when :from and :to languages are given' do


### PR DESCRIPTION
This fixes two issues that we detected today when testing out the 1.0 release - both related to `nil` values in arrays:

1. Translation import from CSV "ate" `nil` values at the beginning of arrays. This is quite a major issue because default Rails translation arrays such as `date.month_names` are given as `[nil, 'January', 'February', ...]` to account for January actually being the 1st, and not 0th month of year.
2. Cloud translation was failing on arrays containing `nil` values. The fix ensures they all come back as `''` - cloud translation providers generally handle `nil` in arrays by truncating them, so we need to pass them to the APIs as just empty strings.