### PR TITLE
Fix/fallback keys firing unnecessary queries

### DIFF
--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -72,6 +72,13 @@ module Lit
       # check in cache or in simple backend
       content = @cache[key_with_locale] || super
       return content if parts.size <= 1
+
+      # if options[:default].is_a?(Array)
+      #   final_fallback_string = options[:default].last if options[:default].last.is_a?(String)
+      #   keys_to_check = [key, *options[:default][0..-2]]
+      #   keys_already_cached = keys_to_check.select { |k| @cache.has_key?("#{locale}.#{k}") }
+      # end
+
       if content.nil? && should_cache?(key_with_locale, options)
         new_content = @cache.init_key_with_value(key_with_locale, content)
         content = new_content if content.nil? # Content can change when Lit.humanize is true for example
@@ -181,7 +188,7 @@ module Lit
 
     def should_cache?(key_with_locale, options)
       if @cache.has_key?(key_with_locale)
-        return false unless options[:default]
+        return false unless options[:default] && !options[:default].is_a?(Array)
       end
 
       _, key_without_locale = ::Lit::Cache.split_key(key_with_locale)

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -73,12 +73,6 @@ module Lit
       content = @cache[key_with_locale] || super
       return content if parts.size <= 1
 
-      # if options[:default].is_a?(Array)
-      #   final_fallback_string = options[:default].last if options[:default].last.is_a?(String)
-      #   keys_to_check = [key, *options[:default][0..-2]]
-      #   keys_already_cached = keys_to_check.select { |k| @cache.has_key?("#{locale}.#{k}") }
-      # end
-
       if content.nil? && should_cache?(key_with_locale, options)
         new_content = @cache.init_key_with_value(key_with_locale, content)
         content = new_content if content.nil? # Content can change when Lit.humanize is true for example

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -128,3 +128,10 @@ VCR.configure do |config|
 end
 
 MinitestVcr::Spec.configure!
+
+def assert_no_database_queries
+  ActiveRecord::Base.connection.stubs(:execute).
+    raises(Minitest::Assertion, 'The block should not make any database calls')
+  yield
+  ActiveRecord::Base.connection.unstub(:execute)
+end

--- a/test/unit/i18n_backend_test.rb
+++ b/test/unit/i18n_backend_test.rb
@@ -62,10 +62,10 @@ class I18nBackendTest < ActiveSupport::TestCase
     fallback_key = :'test.fallback'
 
     # first, when these keys don't exist in the DB yet, they should be created:
-    assert_changes(-> { Lit::LocalizationKey.where(localization_key: [test_key, fallback_key]).count },
-                   from: 0, to: 2) do
-      assert_equal 'foobar', I18n.t(test_key, default: [fallback_key, 'foobar'])
-    end
+    loc_key_count = -> { Lit::LocalizationKey.where(localization_key: [test_key, fallback_key]).count }
+    assert_equal 0, loc_key_count.call
+    assert_equal 'foobar', I18n.t(test_key, default: [fallback_key, 'foobar'])
+    assert_equal 2, loc_key_count.call
 
     # on subsequent translation calls, they should not be fetched from DB
     assert_no_database_queries do


### PR DESCRIPTION
After `I18n.t(test_key, default: [fallback_key, 'foobar'])` is called for the first time ever, with both keys absent from the database, their records should be created, and Lit cache should have `nil` stored for them.

Subsequent calls should not result in triggering any database calls - they should be reading directly from cache. Test scenario:

https://github.com/prograils/lit/blob/980f5ef77b6cdb4a812c0ed08dd017533fe147ed/test/unit/i18n_backend_test.rb#L57

This needed a fix to one of the fairly recently changed spots responsible for a fix of overriding `nil` values when a new default value is given - illustrated with this scenario:

https://github.com/prograils/lit/blob/1c6c9dc9f184f60186443fe2f641171e55743f47/test/unit/lit_behaviour_test.rb#L210