### PR TITLE
Memoize cache keys during startup, reorder conditions for speedup

### DIFF
--- a/test/functional/lit/api/v1/localization_keys_controller_test.rb
+++ b/test/functional/lit/api/v1/localization_keys_controller_test.rb
@@ -13,8 +13,14 @@ module Lit
       Dummy::Application.reload_routes!
       @routes = Lit::Engine.routes
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials('test')
+      Lit.ignore_yaml_on_startup = false
       Lit.init
     end
+
+    def teardown
+      Lit.ignore_yaml_on_startup = nil
+    end
+
     test 'should get index' do
       get :index, format: :json
       assert_response :success

--- a/test/functional/lit/api/v1/localizations_controller_test.rb
+++ b/test/functional/lit/api/v1/localizations_controller_test.rb
@@ -13,7 +13,12 @@ module Lit
       Dummy::Application.reload_routes!
       @routes = Lit::Engine.routes
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials('test')
+      Lit.ignore_yaml_on_startup = false
       Lit.init
+    end
+
+    def teardown
+      Lit.ignore_yaml_on_startup = nil
     end
 
     test 'should get index' do

--- a/test/functional/welcome_controller_test.rb
+++ b/test/functional/welcome_controller_test.rb
@@ -6,7 +6,12 @@ class WelcomeControllerTest < ActionController::TestCase
     Lit::LocalizationKey.delete_all
     Lit::LocalizationVersion.delete_all
     Lit.loader = nil
+    Lit.ignore_yaml_on_startup = false
     Lit.init
+  end
+
+  def teardown
+    Lit.ignore_yaml_on_startup = nil
   end
 
   test 'should properly show index' do

--- a/test/integration/lit/locales_test.rb
+++ b/test/integration/lit/locales_test.rb
@@ -2,6 +2,15 @@
 require 'test_helper'
 
 class LocalesTest < ActionDispatch::IntegrationTest
+  def setup
+    Lit.ignore_yaml_on_startup = false
+    Lit.init
+  end
+
+  def teardown
+    Lit.ignore_yaml_on_startup = nil
+  end
+
   test 'should allow hiding locale' do
     Lit.authentication_function = nil
     # visit('/pl/welcome')

--- a/test/integration/lit/welcome_test.rb
+++ b/test/integration/lit/welcome_test.rb
@@ -5,11 +5,14 @@ class WelcomeTest < ActionDispatch::IntegrationTest
   def setup
     @old_humanize_key = Lit.humanize_key
     @old_fallbacks = Rails.application.config.i18n.fallbacks
+    Lit.ignore_yaml_on_startup = false
+    Lit.init
   end
 
   def teardown
     Lit.humanize_key = @old_humanize_key
     Rails.application.config.i18n.fallbacks = @old_fallbacks
+    Lit.ignore_yaml_on_startup = nil
   end
 
   test "should properly display 'Hello world' in english" do

--- a/test/unit/lit/localization_test.rb
+++ b/test/unit/lit/localization_test.rb
@@ -7,8 +7,13 @@ module Lit
       Lit::LocalizationKey.delete_all
       Lit::LocalizationVersion.delete_all
       Lit.loader = nil
+      Lit.ignore_yaml_on_startup = false
       Lit.init
       I18n.locale = :en
+    end
+
+    def teardown
+      Lit.ignore_yaml_on_startup = nil
     end
 
     test 'does not create version upon creation' do

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -142,6 +142,7 @@ class LitBehaviourTest < ActiveSupport::TestCase
     load_sample_yml('en.yml')
     old_loader = Lit.loader
     Lit.loader = nil
+    Lit.ignore_yaml_on_startup = false
     Lit.init
 
     # Defaults from yml: en.foo: bar, en.nil_thing: [nothing]


### PR DESCRIPTION
During startup process, cached translation keys (typically from Redis) are now memoized in a thread-local variable, so there are no multiple calls to Redis during initial YAML loading. Plus, a number of conditions have been rearranged to ensure that these Redis calls are not done when it's not needed at all.