### PR TITLE
Js translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ translating app by non-technicals.
 
 Highly inspired by Copycopter by thoughtbot.
 
-[![travis status](https://travis-ci.org/prograils/lit.svg)](https://travis-ci.org/prograils/lit)
+[![travis status](https://api.travis-ci.org/3eggert/lit.svg?branch=js_translations)](https://api.travis-ci.org/3eggert/lit.svg?branch=js_translations)
 
 ### Features
 

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -9,6 +9,16 @@ module Lit
       get_localization_keys
     end
 
+    def not_used
+      @scope = @scope.not_used
+      get_localization_keys
+    end
+
+    def used
+      @scope = @scope.used
+      get_localization_keys
+    end
+
     def not_translated
       @scope = @scope.not_completed
       get_localization_keys

--- a/app/models/lit/localization_key.rb
+++ b/app/models/lit/localization_key.rb
@@ -3,6 +3,8 @@ module Lit
     attr_accessor :interpolated_key
 
     ## SCOPES
+    scope :used, -> { where.not(used_last_at: nil) }
+    scope :not_used, -> { where(used_last_at: nil) }
     scope :completed, -> { where(is_completed: true) }
     scope :not_completed, -> { where(is_completed: false) }
     scope :starred, -> { where(is_starred: true) }

--- a/app/views/lit/dashboard/index.html.erb
+++ b/app/views/lit/dashboard/index.html.erb
@@ -1,4 +1,5 @@
 <strong>All localization keys</strong> <%= Lit::LocalizationKey.active.count(:id) %><br/>
+<strong>Used localization keys</strong> <%= Lit::LocalizationKey.where.not(used_last_at: nil).count(:id) %><br/>
 <% @locales.each do |l| %>
   <strong><%= EmojiFlag.new(l.locale) %> <%= I18n.t("lit.locale_to_languages.#{l.locale}", :default=>l.locale) %>:</strong> <span title="<%= "#{l.changed_localizations_count}/#{l.all_localizations_count}" %>"><%= l.translated_percentage %>%</span><br/>
 <% end %>

--- a/app/views/lit/localization_keys/_localizations_list.html.erb
+++ b/app/views/lit/localization_keys/_localizations_list.html.erb
@@ -3,7 +3,11 @@
     <tr class="localization_key_row" data-id="<%= lk.id %>">
       <td>
         <strong><%= lk.localization_key %></strong>
-        <span class="badge"><%= Lit.init.cache.get_global_hits_counter(lk.localization_key) %></span>
+        <% if lk.used_last_at.present? %>
+          <span class="badge"><%= "#{I18n.t('lit.used', default: 'used')} #{lk.usage_count} #{I18n.t('lit.times_since', default: 'times since')} #{l(Lit::LocalizationKey.maximum(:used_last_at), :format => :short4rb)}, #{I18n.t('lit.times_since', default: 'last use')} #{l(lk.used_last_at, :format => :short4rb)}"  %></span>
+        <% else %>
+          <span class="badge"><%= "#{I18n.t('lit.not_used', default: 'not used since')} #{l(Lit::LocalizationKey.maximum(:used_last_at), :format => :short4rb)}" %></span>
+        <% end %>
         <div class="localization_keys_options">
           <% if Lit.store_request_info %>
             <%= link_to '#', class: 'request_info_link title',  title: 'Show / hide request' do %>

--- a/app/views/lit/localization_keys/_sidebar.html.erb
+++ b/app/views/lit/localization_keys/_sidebar.html.erb
@@ -14,13 +14,13 @@
     <ul class="nav nav-pills nav-stacked">
       <li class="<%= "active" if params[:action]=='not_used' %>">
         <%= link_to lit.not_used_localization_keys_path do -%>
-          <%= draw_icon 'pencil' %>
+          <%= draw_icon 'times-circle' %>
           not used
         <% end %>
       </li>
       <li class="<%= "active" if params[:action]=='used' %>">
         <%= link_to lit.used_localization_keys_path do -%>
-          <%= draw_icon 'pencil' %>
+          <%= draw_icon 'check-circle' %>
           used
         <% end %>
       </li>

--- a/app/views/lit/localization_keys/_sidebar.html.erb
+++ b/app/views/lit/localization_keys/_sidebar.html.erb
@@ -12,7 +12,19 @@
       </div>
     <% end %>
     <ul class="nav nav-pills nav-stacked">
-      <li class="<%= "active" if params[:action]=='not_translated' %>">
+      <li class="<%= "active" if params[:action]=='not_used' %>">
+        <%= link_to lit.not_used_localization_keys_path do -%>
+          <%= draw_icon 'pencil' %>
+          not used
+        <% end %>
+      </li>
+      <li class="<%= "active" if params[:action]=='used' %>">
+        <%= link_to lit.used_localization_keys_path do -%>
+          <%= draw_icon 'pencil' %>
+          used
+        <% end %>
+      </li>
+       <li class="<%= "active" if params[:action]=='not_translated' %>">
         <%= link_to lit.not_translated_localization_keys_path do -%>
           <%= draw_icon 'pencil' %>
           not translated

--- a/app/views/lit/localization_keys/not_used.html.erb
+++ b/app/views/lit/localization_keys/not_used.html.erb
@@ -1,0 +1,11 @@
+<h3><%= I18n.t('lit.not_used_header', default: 'Not used localization keys') %></h3>
+
+<%= render 'localizations_list', available_locales: I18n.backend.available_locales %>
+
+<% if defined?(Kaminari)  %>
+  <%= paginate @localization_keys, :theme=>"lit" %>
+<% elsif defined?(WillPaginate)  %>
+  <%= will_paginate @localization_keys %>
+<% end %>
+
+<%= render 'sidebar' %>

--- a/app/views/lit/localization_keys/used.html.erb
+++ b/app/views/lit/localization_keys/used.html.erb
@@ -1,0 +1,11 @@
+<h3><%= I18n.t('lit.used_header', default: 'Used localization keys') %></h3>
+
+<%= render 'localizations_list', available_locales: I18n.backend.available_locales %>
+
+<% if defined?(Kaminari)  %>
+  <%= paginate @localization_keys, :theme=>"lit" %>
+<% elsif defined?(WillPaginate)  %>
+  <%= will_paginate @localization_keys %>
+<% end %>
+
+<%= render 'sidebar' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Lit::Engine.routes.draw do
       get :starred
       get :find_localization
       get :not_translated
+      get :not_used
+      get :used
       get :visited_again
     end
     resources :localizations, only: [:edit, :update, :show] do

--- a/db/migrate/20200227082719_lit_add_usage_count_and_used_last_at_to_lit_localization_keys.rb
+++ b/db/migrate/20200227082719_lit_add_usage_count_and_used_last_at_to_lit_localization_keys.rb
@@ -1,0 +1,8 @@
+class LitAddUsageCountAndUsedLastAtToLitLocalizationKeys < Rails::VERSION::MAJOR >= 5   ?
+                                       ActiveRecord::Migration[4.2] :
+                                       ActiveRecord::Migration
+  def change
+    add_column :lit_localization_keys, :usage_count, :integer, index: true
+    add_column :lit_localization_keys, :used_last_at, :datetime, index: true
+  end
+end

--- a/lib/generators/lit/install/templates/initializer.rb
+++ b/lib/generators/lit/install/templates/initializer.rb
@@ -50,7 +50,7 @@ Lit.set_last_updated_at_upon_creation = true
 # For more information please check the README.md
 Lit.store_request_info = false
 
-# Initialize lit
-Lit.init
+# Initialize lit unless it ist disabled by setting the SKIP_LIT enviroment variable. Disabling is usefull to speed up the startup, for example to execute migrations
+Lit.init unless ENV["SKIP_LIT"] == "1"
 
 

--- a/lib/generators/lit/install/templates/initializer.rb
+++ b/lib/generators/lit/install/templates/initializer.rb
@@ -50,6 +50,9 @@ Lit.set_last_updated_at_upon_creation = true
 # For more information please check the README.md
 Lit.store_request_info = false
 
+# Persist global_hits_counter every 1000 lookups, set to nil or comment out to disable
+Lit.persit_global_hits_count = 1000 
+
 # Initialize lit unless it ist disabled by setting the SKIP_LIT enviroment variable. Disabling is usefull to speed up the startup, for example to execute migrations
 Lit.init unless ENV["SKIP_LIT"] == "1"
 

--- a/lib/lit.rb
+++ b/lib/lit.rb
@@ -17,6 +17,7 @@ module Lit
   mattr_accessor :all_translations_are_html_safe
   mattr_accessor :set_last_updated_at_upon_creation
   mattr_accessor :store_request_info
+  mattr_accessor :persit_global_hits_count
 
   class << self
     attr_accessor :loader

--- a/lib/lit/cache.rb
+++ b/lib/lit/cache.rb
@@ -20,6 +20,7 @@ module Lit
   class Cache
     def initialize
       @hits_counter = Lit.get_key_value_engine
+      @hits = 0
       @request_info_store = Lit.get_key_value_engine
       @hits_counter_working = true
       @keys = nil
@@ -141,6 +142,15 @@ module Lit
 
     def get_global_hits_counter(key)
       @hits_counter['global_hits_counter.' + key]
+    end
+
+    def persit_global_hits_counters
+      @hits_counter.each do |k,v|
+        if k.match?(/^global_hits_counter/)
+          localization_key = find_localization_key(k.gsub("global_hits_counter.", ""))
+          localization_key.update_columns(usage_count: @hits_counter[k] + localization_key.usage_count.to_i, used_last_at: Time.now)
+        end
+      end
     end
 
     def get_hits_counter(key)
@@ -310,6 +320,8 @@ module Lit
     def update_hits_count(key)
       return unless @hits_counter_working
       key_without_locale = split_key(key).last
+      @hits += 1
+      persit_global_hits_counters if Lit.persit_global_hits_count.present? && (@hits%Lit.persit_global_hits_count) == 0
       @hits_counter.incr('hits_counter.' + key)
       @hits_counter.incr('global_hits_counter.' + key_without_locale)
     end

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -75,7 +75,7 @@ module Lit
           nested_keys.merge!(converted, &deep_proc)
         end
       end
-      if (key_selector.present? && key_parts[1] == key_selector)
+      if key_selector.present?
         "var js_locale= #{nested_keys}"
       else
         nested_keys

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -3,7 +3,7 @@ require 'csv'
 module Lit
   class Export
     def self.call(locale_keys:, format:, include_hits_count: false)
-      raise ArgumentError, "format must be yaml or csv" if %i[yaml csv].exclude?(format)
+      raise ArgumentError, "format must be yaml or csv" if %i[yaml_js yaml csv].exclude?(format)
       Lit.loader.cache.load_all_translations
       localizations_scope = Lit::Localization.active
       if locale_keys.present?
@@ -19,7 +19,10 @@ module Lit
       when :yaml
         exported_keys = nested_string_keys_to_hash(db_localizations)
         exported_keys.to_yaml
-      when :csv
+      when :yaml_js
+        exported_keys = nested_string_keys_to_hash(db_localizations, "javascript")
+        exported_keys.to_yaml
+       when :csv
         relevant_locales = locale_keys.presence || I18n.available_locales.map(&:to_s)
         CSV.generate do |csv|
           csv << ['key', *relevant_locales, ('hits' if include_hits_count)].compact
@@ -55,7 +58,7 @@ module Lit
       end
     end
 
-    private_class_method def self.nested_string_keys_to_hash(db_localizations)
+    private_class_method def self.nested_string_keys_to_hash(db_localizations, key_selector=nil)
       # http://subtech.g.hatena.ne.jp/cho45/20061122
       deep_proc = proc do |_k, s, o|
         if s.is_a?(Hash) && o.is_a?(Hash)
@@ -66,8 +69,10 @@ module Lit
       nested_keys = {}
       db_localizations.sort.each do |k, v|
         key_parts = k.to_s.split('.')
-        converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
-        nested_keys.merge!(converted, &deep_proc)
+        if (key_selector.present? && key_parts[0] == key_selector) || key_selector.nil?
+          converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
+          nested_keys.merge!(converted, &deep_proc)
+        end
       end
       nested_keys
     end

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -3,7 +3,7 @@ require 'csv'
 module Lit
   class Export
     def self.call(locale_keys:, format:, include_hits_count: false)
-      raise ArgumentError, "format must be yaml, yaml_js or csv" if %i[yaml_js yaml csv].exclude?(format)
+      raise ArgumentError, "format must be yaml, json_js or csv" if %i[json_js yaml csv].exclude?(format)
       Lit.loader.cache.load_all_translations
       localizations_scope = Lit::Localization.active
       if locale_keys.present?
@@ -19,7 +19,7 @@ module Lit
       when :yaml
         exported_keys = nested_string_keys_to_hash(db_localizations)
         exported_keys.to_yaml
-      when :yaml_js
+      when :json_js
         exported_keys = nested_string_keys_to_hash(db_localizations, "javascript")
         exported_keys.to_json
        when :csv

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -69,7 +69,6 @@ module Lit
       nested_keys = {}
       db_localizations.sort.each do |k, v|
         key_parts = k.to_s.split('.')
-        puts "-------------_> #{key_parts.inspect}"
         if (key_selector.present? && key_parts[1] == key_selector) || key_selector.nil?
           converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
           nested_keys.merge!(converted, &deep_proc)

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -70,11 +70,16 @@ module Lit
       db_localizations.sort.each do |k, v|
         key_parts = k.to_s.split('.')
         if (key_selector.present? && key_parts[1] == key_selector) || key_selector.nil?
+          key_parts.drop(2) if key_selector.present? 
           converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
           nested_keys.merge!(converted, &deep_proc)
         end
       end
-      nested_keys
+      if (key_selector.present? && key_parts[1] == key_selector)
+        "var js_locale= #{nested_keys}"
+      else
+        nested_keys
+      end
     end
 
     # This is like Array#transpose but ignores size differences between inner arrays.

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -3,7 +3,7 @@ require 'csv'
 module Lit
   class Export
     def self.call(locale_keys:, format:, include_hits_count: false)
-      raise ArgumentError, "format must be yaml or csv" if %i[yaml_js yaml csv].exclude?(format)
+      raise ArgumentError, "format must be yaml, yaml_js or csv" if %i[yaml_js yaml csv].exclude?(format)
       Lit.loader.cache.load_all_translations
       localizations_scope = Lit::Localization.active
       if locale_keys.present?
@@ -21,7 +21,7 @@ module Lit
         exported_keys.to_yaml
       when :yaml_js
         exported_keys = nested_string_keys_to_hash(db_localizations, "javascript")
-        exported_keys.to_yaml
+        exported_keys.to_json
        when :csv
         relevant_locales = locale_keys.presence || I18n.available_locales.map(&:to_s)
         CSV.generate do |csv|
@@ -69,7 +69,8 @@ module Lit
       nested_keys = {}
       db_localizations.sort.each do |k, v|
         key_parts = k.to_s.split('.')
-        if (key_selector.present? && key_parts[0] == key_selector) || key_selector.nil?
+        puts "-------------_> #{key_parts.inspect}"
+        if (key_selector.present? && key_parts[1] == key_selector) || key_selector.nil?
           converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
           nested_keys.merge!(converted, &deep_proc)
         end

--- a/lib/lit/export.rb
+++ b/lib/lit/export.rb
@@ -21,7 +21,7 @@ module Lit
         exported_keys.to_yaml
       when :json_js
         exported_keys = nested_string_keys_to_hash(db_localizations, "javascript")
-        exported_keys.to_json
+        "var js_locale= " + exported_keys.to_json
        when :csv
         relevant_locales = locale_keys.presence || I18n.available_locales.map(&:to_s)
         CSV.generate do |csv|
@@ -70,16 +70,12 @@ module Lit
       db_localizations.sort.each do |k, v|
         key_parts = k.to_s.split('.')
         if (key_selector.present? && key_parts[1] == key_selector) || key_selector.nil?
-          key_parts.drop(2) if key_selector.present? 
+          key_parts = key_parts.drop(2) if key_selector.present? 
           converted = key_parts.reverse.reduce(v) { |a, n| { n => a } }
           nested_keys.merge!(converted, &deep_proc)
         end
       end
-      if key_selector.present?
-        "var js_locale= #{nested_keys}"
-      else
-        nested_keys
-      end
+      nested_keys
     end
 
     # This is like Array#transpose but ignores size differences between inner arrays.


### PR DESCRIPTION
I added a new export format which writes the translations in a js file to use it with java script. 

In addition I wrote a mechanism to track which keys are actually used. The usage count and date of the last usage is written to the database and displayed in the localization view. I meant to help to delete unused keys.  To enable this feature I added this config option:
# Persist global_hits_counter every 1000 lookups, set to nil or comment out to disable
Lit.persit_global_hits_count = 1000 

I also added this config option to speed up the startup, for cases where lit is not needed:
# Initialize lit unless it ist disabled by setting the SKIP_LIT enviroment variable. Disabling is usefull to speed up the startup, for example to execute migrations
Lit.init unless ENV["SKIP_LIT"] == "1"
 