### PR TITLE
Resolve redis-rb warning exists => exists?

### DIFF
--- a/lib/lit/adapters/redis_storage.rb
+++ b/lib/lit/adapters/redis_storage.rb
@@ -17,9 +17,9 @@ module Lit
     end
 
     def [](key)
-      if Lit.redis.exists(_prefixed_key_for_array(key))
+      if Lit.redis.exists?(_prefixed_key_for_array(key))
         Lit.redis.lrange(_prefixed_key(key), 0, -1)
-      elsif Lit.redis.exists(_prefixed_key_for_nil(key))
+      elsif Lit.redis.exists?(_prefixed_key_for_nil(key))
         nil
       else
         Lit.redis.get(_prefixed_key(key))
@@ -56,7 +56,7 @@ module Lit
     end
 
     def has_key?(key)
-      Lit.redis.exists(_prefixed_key(key))
+      Lit.redis.exists?(_prefixed_key(key))
     end
     alias key? has_key?
 

--- a/lib/lit/adapters/redis_storage.rb
+++ b/lib/lit/adapters/redis_storage.rb
@@ -16,10 +16,18 @@ module Lit
       Lit.redis
     end
 
+    # This handles a change in the redis-rb gem that changes exists => exists?
+    def exists?(key)
+      # Use recommended binary-returning method create [with this redis-rb commit](https://github.com/redis/redis-rb/commit/bf42fc9e0db4a1719d9b1ecc65aeb20425d44427).
+      return Lit.redis.exists?(key) if Lit.redis.respond_to?(:exists?)
+      # Fall back with older gem
+      Lit.redis.exists(key)
+    end
+    
     def [](key)
-      if Lit.redis.exists?(_prefixed_key_for_array(key))
+      if self.exists?(_prefixed_key_for_array(key))
         Lit.redis.lrange(_prefixed_key(key), 0, -1)
-      elsif Lit.redis.exists?(_prefixed_key_for_nil(key))
+      elsif self.exists?(_prefixed_key_for_nil(key))
         nil
       else
         Lit.redis.get(_prefixed_key(key))
@@ -56,7 +64,7 @@ module Lit
     end
 
     def has_key?(key)
-      Lit.redis.exists?(_prefixed_key(key))
+      self.exists?(_prefixed_key(key))
     end
     alias key? has_key?
 


### PR DESCRIPTION
Resolving this warning message ensuring future compatibility:
```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/Users/jonathan/.rvm/gems/ruby-2.7.1/bundler/gems/lit-f3e8ccbf6201/lib/lit/adapters/redis_storage.rb:22:in `[]')
```