### PR TITLE
Resolve error when service does not exist

### DIFF
--- a/app/services/remote_interactor_service.rb
+++ b/app/services/remote_interactor_service.rb
@@ -11,6 +11,7 @@ class RemoteInteractorService
   rescue => e
     return unless defined?(Rails)
     ::Rails.logger.error { "Lit remote error: #{e}" }
+    nil # Return nil to be consistent with checks for .nil? otherwise returns True
   end
 
   private


### PR DESCRIPTION
When service doesn't connect, error case returns True, but upstream checks for nil.