### PR TITLE
When raw option is true, the import should update defalut_value

### DIFF
--- a/lib/lit/import.rb
+++ b/lib/lit/import.rb
@@ -136,17 +136,20 @@ module Lit
         # is the array
         val = value.is_a?(Array) ? [value] : value
         I18n.t(key, default: val)
-        unless @raw
-          # this indicates that this translation already exists
-          existing_translation =
-            Lit::Localization.joins(:locale, :localization_key)
-                             .find_by('localization_key = ? and locale = ?',
-                                      key, locale)
-          if existing_translation
-            existing_translation.update(translated_value: value, is_changed: true)
-            lkey = existing_translation.localization_key
-            lkey.update(is_deleted: false) if lkey.is_deleted
-          end
+
+        # this indicates that this translation already exists
+        existing_translation =
+        Lit::Localization.joins(:locale, :localization_key)
+                         .find_by('localization_key = ? and locale = ?', key, locale)
+
+        return unless existing_translation
+        
+        if @raw
+          existing_translation.update(default_value: value)
+        else
+          existing_translation.update(translated_value: value, is_changed: true)
+          lkey = existing_translation.localization_key
+          lkey.update(is_deleted: false) if lkey.is_deleted
         end
       end
     end

--- a/test/unit/import_test.rb
+++ b/test/unit/import_test.rb
@@ -32,8 +32,7 @@ class ImportTest < ActiveSupport::TestCase
       end
     end
 
-    test 'does not override existing default or translated localization ' \
-         "values in raw mode (#{format})" do
+    test "override only default but not translated in raw mode (#{format})" do
       input = imported_file("import.#{ext}.normal")
       I18n.with_locale(:en) { I18n.t('scopes.foo', default: 'bar') }
       I18n.with_locale(:pl) { I18n.t('scopes.foo', default: 'baz') }
@@ -47,9 +46,9 @@ class ImportTest < ActiveSupport::TestCase
 
       pl_loc = foo_key_localizations.find_by("locale = 'pl'")
       assert(pl_loc.translated_value == 'bazzz')
-      assert(pl_loc.default_value == 'baz')
+      assert(pl_loc.default_value == 'foo pl')
       assert(
-        foo_key_localizations.find_by("locale = 'en'").default_value == 'bar'
+        foo_key_localizations.find_by("locale = 'en'").default_value == 'foo en'
       )
     end
 


### PR DESCRIPTION
Importing YML or CSV file in raw mode should only update default_value but not translated_value.
According to the [code-comments](https://github.com/prograils/lit/blob/master/lib/lit/import.rb#L122), I think was the expected behavior.