### PR TITLE
Fix Rails constant reference in check_if_table_exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ These credentials can be given in three ways:
       ... # see Google docs link above for reference
     }
   end
+  
+  # For example, for Rails 6, from encrypted credentials file (HashWithIndifferentAccess is used, because the keys in
+   the credentials.config could be strings or, as well, symbols):
+  
+  Lit::CloudTranslation.configure do |config|
+    config.keyfile_hash = HashWithIndifferentAccess.new(Rails.application.credentials.config[:google_translate_api])
+  end
   ```
 * directly via `GOOGLE_TRANSLATE_API_<element>` environment variables, where e.g. the `GOOGLE_TRANSLATE_API_PROJECT_ID` variable corresponds to the `project_id` element of a JSON keyfile. Typically, only the following variables are mandatory:
   * `GOOGLE_TRANSLATE_API_PROJECT_ID`

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Lit::CloudTranslation.provider = Lit::CloudTranslation::Providers::Google
 
 ...and make sure you have this in your Gemfile:
 ```
-gem 'google-cloud-translate'
+gem 'google-cloud-translate', '~> 1.2.4'
 ```
 
 To use translation via Google, you need to obtain a [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) containing all the credentials required by the API.
@@ -273,7 +273,8 @@ Lit.store_request_info = true
 1. `gem install bundler && bundle install` - ensure Bundler and all required gems are installed
 2. `bundle exec appraisal install` - install gems from appraisal's gemfiles
 3. `cp test/dummy/config/database.yml.sample test/dummy/config/database.yml` - move a database.yml in place (remember to fill your DB credentials in it)
-4. `RAILS_ENV=test appraisal rails-5.2 rake db:setup` - setup lit DB (see test/config/database.yml); do it only once, it does not matter which Rails version you use for `appraisal`
+4. `RAILS_ENV=test bundle exec appraisal rails-5.2 rake db:setup` - setup lit DB (see test/config/database.yml); do it
+ only once, it does not matter which Rails version you use for `appraisal`
 5. `bundle exec appraisal rake` - run the tests!
 
 ### License

--- a/lib/lit.rb
+++ b/lib/lit.rb
@@ -54,7 +54,7 @@ module Lit
       "Error: #{e.message}\n\n" \
       "Backtrace:\n" \
       "#{e.backtrace.join("\n")}"
-    Logger.new(STDOUT).error(log_txt) if Rails.env.test? # ensure this is logged to stdout in test
+    Logger.new(STDOUT).error(log_txt) if ::Rails.env.test? # ensure this is logged to stdout in test
     ::Rails.logger.error(log_txt)
     false
   end


### PR DESCRIPTION
Fix description of adding google-cloud-translate into Gemfile to have the version constraint specified to 1.2.4, because there is no compatibility with more recent versions.

Fix description of the db:setup task to specify running it with bundle exec.