### PR TITLE
Modify generated initializer to include ignored_keys

### DIFF
--- a/lib/generators/lit/install/templates/initializer.rb
+++ b/lib/generators/lit/install/templates/initializer.rb
@@ -29,10 +29,13 @@ Lit.all_translations_are_html_safe = false
 # <span title="translation missing string"></span>
 Lit.humanize_key = false
 
-# If set to `true` will always parse yaml files upon startup and update cache
-# values with ones with yaml - but only, if those keys haven't been changed via
-# web ui before
+# If set to `false` will always parse yaml files upon startup and update cached
+# values with ones with yaml (but only, if those keys haven't been changed via
+# web ui before)
 Lit.ignore_yaml_on_startup = true
+
+# Array of ignored keys or key prefixes
+Lit.ignored_keys = ['i18n.transliterate'].freeze
 
 # API enabled? API allows third party browsing your translations, as well as
 # synchronizing them between environments

--- a/lib/lit.rb
+++ b/lib/lit.rb
@@ -33,10 +33,10 @@ module Lit
       Lit.humanize_key_ignored = %r{(#{Lit.humanize_key_ignored.join('|')}).*}
       if Lit.ignored_keys.is_a?(String)
         keys = Lit.ignored_keys.split(',').map(&:strip)
-        Lit.ignored_keys = keys
+        Lit.ignored_keys = keys.freeze
       end
       Lit.ignore_yaml_on_startup = true if Lit.ignore_yaml_on_startup.nil?
-      Lit.ignored_keys = [] unless Lit.ignored_keys.is_a?(Array)
+      Lit.ignored_keys = [].freeze unless Lit.ignored_keys.is_a?(Array)
       # if loading all translations on start, migrations have to be already
       # performed, fails on first deploy
       # self.loader.cache.load_all_translations


### PR DESCRIPTION
Let's add `Lit.ignored_keys = ['i18n.transliterate']` as a default to generated initializer