### PR TITLE
Adds #172 - Option to touch localizations

### DIFF
--- a/app/assets/stylesheets/lit/application.css
+++ b/app/assets/stylesheets/lit/application.css
@@ -11,17 +11,17 @@
  *= require './backend/jquery-te-1.4.0.css'
  *= require_self
  */
-.detail_wrapper{
-  padding: 10px 0 0 50px;
+.detail_wrapper {
+  padding: 10px 0 0 10px;
 }
-.detail_wrapper table tr td.locale_row{
+.detail_wrapper table tr td.locale_row {
   width: 75px;
 }
-.localization_key_row .localization_keys_options{
+.localization_key_row .localization_keys_options {
   display: none;
   float: right;
 }
-.localization_key_row:hover .localization_keys_options{
+.localization_key_row:hover .localization_keys_options {
   display: block;
 }
 
@@ -29,29 +29,29 @@ li.key_prefix .fa-chevron-right {
   float: right;
   margin-top: 2px;
   margin-right: -6px;
-  opacity: .25;
+  opacity: 0.25;
 }
 
-.hidden{
+.hidden {
   display: none;
 }
-i.fa{
+i.fa {
   color: black;
 }
-.nav.nav-stacked>li>a {
-padding: 5px 7px;
+.nav.nav-stacked > li > a {
+  padding: 5px 7px;
 }
-.well{
+.well {
   background-color: white;
   border-radius: 0px;
 }
-.well label{
+.well label {
   font-weight: normal;
 }
 .well .form-search {
   margin-bottom: 15px;
 }
-.localization_row em{
+.localization_row em {
   color: #bbb;
 }
 .loading {

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -116,15 +116,12 @@ module Lit
       @_localization_for ||= {}
       key = [locale, localization_key]
       ret = @_localization_for[key]
-      binding.pry if localization_key == 'scopes.string'
       if ret == false
         nil
       elsif ret.nil?
         ret = grouped_localizations[localization_key][locale]
         unless ret
-          ::Rails.logger.info "******** REFRESHING the key"
           Lit.init.cache.refresh_key("#{locale}.#{localization_key.localization_key}")
-          ::Rails.logger.info "******** FETCHING the key"
           ret = localization_key.localizations.where(locale_id: Lit.init.cache.find_locale(locale).id).first
         end
         @_localization_for[key] = ret ? ret : false

--- a/app/controllers/lit/localization_keys_controller.rb
+++ b/app/controllers/lit/localization_keys_controller.rb
@@ -1,9 +1,7 @@
 module Lit
   class LocalizationKeysController < ::Lit::ApplicationController
-    before_action :find_localization_scope,
-                  except: %i[destroy find_localization]
-    before_action :find_localization_key,
-                  only: %i[star destroy change_completed restore_deleted]
+    before_action :find_localization_scope, except: %i[destroy find_localization]
+    before_action :find_localization_key, only: %i[star destroy change_completed restore_deleted]
 
     def index
       get_localization_keys
@@ -20,27 +18,19 @@ module Lit
     end
 
     def find_localization
-      localization_key = Lit::LocalizationKey.find_by!(
-        localization_key: params[:key]
-      )
+      localization_key = Lit::LocalizationKey.find_by!(localization_key: params[:key])
       locale = Lit::Locale.find_by!(locale: params[:locale])
       localization = localization_key.localizations.find_by(locale_id: locale)
-      render json: {
-        path: localization_key_localization_path(localization_key, localization)
-      }
+      render json: { path: localization_key_localization_path(localization_key, localization) }
     end
 
     def starred
       @scope = @scope.where(is_starred: true)
 
-      if defined?(Kaminari) &&
-         @scope.respond_to?(Kaminari.config.page_method_name)
+      if defined?(Kaminari) && @scope.respond_to?(Kaminari.config.page_method_name)
         @scope = @scope.send(Kaminari.config.page_method_name, params[:page])
       end
-      if defined?(WillPaginate) &&
-         @scope.respond_to?(:paginate)
-        @scope = @scope.paginate(page: params[:page])
-      end
+      @scope = @scope.paginate(page: params[:page]) if defined?(WillPaginate) && @scope.respond_to?(:paginate)
       get_localization_keys
       render action: :index
     end
@@ -66,6 +56,16 @@ module Lit
       respond_to :js
     end
 
+    def batch_touch
+      get_localization_keys
+      localization_key_ids = @scope.distinct(false).pluck(:id)
+      if localization_key_ids.any?
+        @scope.distinct(false).update_all updated_at: Time.current
+        Localization.where(localization_key_id: localization_key_ids).update_all updated_at: Time.current
+      end
+      respond_to :js
+    end
+
     private
 
     def find_localization_key
@@ -73,19 +73,16 @@ module Lit
     end
 
     def find_localization_scope
-      @search_options = if params.respond_to?(:permit)
-                          params.permit(*valid_keys)
-                        else
-                          params.slice(*valid_keys)
-                        end
-      @scope = LocalizationKey.distinct.active
-                              .preload(localizations: :locale)
-                              .search(@search_options)
+      @search_options = params.respond_to?(:permit) ? params.permit(*valid_keys) : params.slice(*valid_keys)
+      @scope = LocalizationKey.distinct.active.preload(localizations: :locale).search(@search_options)
     end
 
     def get_localization_keys
       key_parts = @search_options[:key_prefix].to_s.split('.').length
-      @prefixes = @scope.reorder(nil).distinct.pluck(:localization_key).map { |lk| lk.split('.').shift(key_parts + 1).join('.') }.uniq.sort
+      @prefixes =
+        @scope.reorder(nil).distinct.pluck(:localization_key).map do |lk|
+          lk.split('.').shift(key_parts + 1).join('.')
+        end.uniq.sort
       if @search_options[:key_prefix].present?
         parts = @search_options[:key_prefix].split('.')
         @parent_prefix = parts[0, parts.length - 1].join('.')
@@ -104,28 +101,30 @@ module Lit
     end
 
     def grouped_localizations
-      @_grouped_localizations ||= begin
-        {}.tap do |hash|
-          @localization_keys.each do |lk|
-            hash[lk] = {}
-            lk.localizations.each do |l|
-              hash[lk][l.locale.locale.to_sym] = l
+      @_grouped_localizations ||=
+        begin
+          {}.tap do |hash|
+            @localization_keys.each do |lk|
+              hash[lk] = {}
+              lk.localizations.each { |l| hash[lk][l.locale.locale.to_sym] = l }
             end
           end
         end
-      end
     end
 
     def localization_for(locale, localization_key)
       @_localization_for ||= {}
       key = [locale, localization_key]
       ret = @_localization_for[key]
+      binding.pry if localization_key == 'scopes.string'
       if ret == false
         nil
       elsif ret.nil?
         ret = grouped_localizations[localization_key][locale]
         unless ret
+          ::Rails.logger.info "******** REFRESHING the key"
           Lit.init.cache.refresh_key("#{locale}.#{localization_key.localization_key}")
+          ::Rails.logger.info "******** FETCHING the key"
           ret = localization_key.localizations.where(locale_id: Lit.init.cache.find_locale(locale).id).first
         end
         @_localization_for[key] = ret ? ret : false
@@ -136,12 +135,16 @@ module Lit
     helper_method :localization_for
 
     def versions?(localization)
-      @_versions ||= begin
-        ids = grouped_localizations.values.map(&:values).flatten.map(&:id)
-        Lit::Localization.active.where(id: ids).joins(:versions).group(
-          "#{Lit::Localization.quoted_table_name}.id"
-        ).count
-      end
+      @_versions ||=
+        begin
+          ids = grouped_localizations.values.map(&:values).flatten.map(&:id)
+          Lit::Localization
+            .active
+            .where(id: ids)
+            .joins(:versions)
+            .group("#{Lit::Localization.quoted_table_name}.id")
+            .count
+        end
       @_versions[localization.id].to_i > 0
     end
     helper_method :versions?

--- a/app/views/lit/localization_keys/_localizations_list.html.erb
+++ b/app/views/lit/localization_keys/_localizations_list.html.erb
@@ -1,4 +1,7 @@
-<table class="table">
+<div class="col-12 text-right">
+  <%= link_to "batch touch", lit.batch_touch_localization_keys_path(key: params[:key], key_prefix: params[:key_prefix]), method: :post, remote: true, class: 'btn btn-sm btn-primary', data: { confirm: 'This will "touch" all search results making them subject of synchronization. Proceed?'} %>
+</div>
+<table class="table mt-1">
   <%- @localization_keys.each do |lk| %>
     <tr class="localization_key_row" data-id="<%= lk.id %>">
       <td>
@@ -30,26 +33,30 @@
         <div class="detail_wrapper">
           <table class="table table-bordered table-striped">
             <tr>
-              <th class="col-md-8">Translation</th>
-              <th class="col-md-2 text-center">Locale</th>
+              <th class="col-md-1"></th>
+              <th class="col-md-9">Translation</th>
+              <th class="col-md-1 text-center">Locale</th>
               <% unless lk.is_deleted? %>
-                <th class="col-md-2 text-center">Completed</th>
+                <th class="col-md-1 text-center">Completed</th>
               <% end %>
             </tr>
             <%- available_locales.each do |locale| %>
               <%- localization = localization_for(locale, lk) %>
               <tr>
+                <td>
+                  <% if localization %>
+                    <%= draw_icon 'clock-o', title: "Last updated at #{localization.updated_at.to_s(:db)}" %>
+                    <%= link_to lit.previous_versions_localization_key_localization_path(lk, localization, format: :js), class: "show_prev_versions #{'hidden' unless versions?(localization)}", remote: true do %>
+                      <%= draw_icon 'random', title: I18n.t('lit.common.previous_versions', default: 'Previous versions') %>
+                    <% end %>
+                  <% end %>
+                </td>
                 <td class="localization_row" data-id="<%= localization.id%>" data-edit="<%= edit_localization_key_localization_path(lk, localization, format: :js) %>" data-editing=0 data-content="">
                   <%= render partial: 'localization_row', locals: {localization: Lit.init.cache["#{locale}.#{lk.localization_key}"]} %>
                 </td>
                 <td class="locale_row text-center">
                   <%= EmojiFlag.new(locale) %>
                   <%= locale %>
-                  <% if localization %>
-                    <%= link_to lit.previous_versions_localization_key_localization_path(lk, localization, format: :js), class: "show_prev_versions #{'hidden' unless versions?(localization)}", remote: true do %>
-                      <%= draw_icon 'random', title: I18n.t('lit.common.previous_versions', default: 'Previous versions') %>
-                    <% end %>
-                  <% end %>
                 </td>
                 <% unless lk.is_deleted? %>
                   <td class="text-center">
@@ -65,7 +72,7 @@
             <% end %>
             <% if Lit.store_request_info %>
               <tr class="hidden request_info_row">
-                <td colspan="2">
+                <td colspan="3">
                   <strong>Translation key recently displayed on following pages:</strong>
                   <ul>
                     <% Lit.init.cache.get_request_info(lk.localization_key).split(' ').reverse.each do |l| %>

--- a/app/views/lit/localization_keys/_localizations_list.html.erb
+++ b/app/views/lit/localization_keys/_localizations_list.html.erb
@@ -46,7 +46,7 @@
                 <td>
                   <% if localization %>
                     <%= draw_icon 'clock-o', title: "Last updated at #{localization.updated_at.to_s(:db)}" %>
-                    <%= link_to lit.previous_versions_localization_key_localization_path(lk, localization, format: :js), class: "show_prev_versions #{'hidden' unless versions?(localization)}", remote: true do %>
+                    <%= link_to lit.previous_versions_localization_key_localization_path(lk, localization, format: :js), class: "js-show_prev_versions #{'hidden' unless versions?(localization)}", remote: true do %>
                       <%= draw_icon 'random', title: I18n.t('lit.common.previous_versions', default: 'Previous versions') %>
                     <% end %>
                   <% end %>

--- a/app/views/lit/localization_keys/batch_touch.js.erb
+++ b/app/views/lit/localization_keys/batch_touch.js.erb
@@ -1,0 +1,1 @@
+alert('All of search results have been marked as updated now, please retry synchronizing now');

--- a/app/views/lit/localizations/update.js.erb
+++ b/app/views/lit/localizations/update.js.erb
@@ -1,6 +1,6 @@
 var $row = $('td.localization_row[data-id="<%= @localization.id %>"]');
 $row.data('editing', 0);
 $row.html("<%= ejs render(:partial=>"/lit/localization_keys/localization_row", formats: ['html'], :locals=>{:localization=>@localization.translated_value }) %>");
-$row.siblings().find('.show_prev_versions').removeClass('hidden');
+$row.siblings().find('.js-show_prev_versions').removeClass('hidden');
 $('a.change_completed_<%= @localization.id %> input[type=checkbox]').prop("checked", true);
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Lit::Engine.routes.draw do
       get :find_localization
       get :not_translated
       get :visited_again
+      post :batch_touch
     end
     resources :localizations, only: [:edit, :update, :show] do
       member do

--- a/test/functional/lit/localization_keys_controller_test.rb
+++ b/test/functional/lit/localization_keys_controller_test.rb
@@ -71,6 +71,21 @@ module Lit
       assert_not @localization_key.reload.is_deleted
     end
 
+    test 'touches search results in batch' do
+      v = lit_localization_keys(:string)
+      a = lit_localization_keys(:array)
+      v.update_column :updated_at, 1.day.ago
+      a.update_column :updated_at, 1.day.ago
+      post :batch_touch, params: { key: 'value' }, format: :js
+      assert v.reload.updated_at > 1.second.ago
+      assert a.reload.updated_at < 23.hours.ago
+    end
+
+    test 'wont fail when there wont be any search results when touching in batch' do
+      post :batch_touch, params: { key: 'valuefoobar' }, format: :js
+      assert_response :success
+    end
+
     private
 
     def with_fresh_cache

--- a/test/functional/lit/localization_keys_controller_test.rb
+++ b/test/functional/lit/localization_keys_controller_test.rb
@@ -77,8 +77,8 @@ module Lit
       v.update_column :updated_at, 1.day.ago
       a.update_column :updated_at, 1.day.ago
       post :batch_touch, params: { key: 'value' }, format: :js
-      assert v.reload.updated_at > 1.second.ago
-      assert a.reload.updated_at < 23.hours.ago
+      assert_in_delta(v.reload.updated_at, 1.second.ago, 5)
+      assert_in_delta(a.reload.updated_at, 1.day.ago, 5)
     end
 
     test 'wont fail when there wont be any search results when touching in batch' do


### PR DESCRIPTION
Adds options to allow "touching" localizations in batch - this is useful for situations with synchronizations. All "touched" localizations will be for sure subject of next synchronization. 
<img width="1167" alt="Screenshot 2021-04-23 at 14 34 10" src="https://user-images.githubusercontent.com/302747/115871624-12ca2800-a441-11eb-910c-f71c31a00fa7.png">
<img width="1164" alt="Screenshot 2021-04-23 at 14 34 20" src="https://user-images.githubusercontent.com/302747/115871634-165daf00-a441-11eb-8afa-8232655ac38e.png">
<img width="1162" alt="Screenshot 2021-04-23 at 14 34 26" src="https://user-images.githubusercontent.com/302747/115871641-18277280-a441-11eb-808e-44117cdbf2e1.png">
