### PR TITLE
Fix upsert comment

### DIFF
--- a/lib/lit/import.rb
+++ b/lib/lit/import.rb
@@ -119,12 +119,13 @@ module Lit
     # This is mean to insert a value for a key in a given locale
     # using some kind of strategy which depends on the service's options.
     #
-    # For instance, when @raw option is true (it's the default),
-    # if a key already exists, it overrides the default_value of the
-    # existing localization key; otherwise, with @raw set to false,
-    # it keeps the default as it is and, no matter if a translated value
-    # is there, translated_value is overridden with the imported one
-    # and is_changed is set to true.
+    # For instance, when @raw option is false (it's the default),
+    # if a key already exists its default_value is kept, but the
+    # translated_value is overridden with the imported one and is_changed
+    # is set to true. 
+    # When @raw is true the translation is kept the same, but the
+    # default_value overridden.
+    
     def upsert(locale, key, value) # rubocop:disable Metrics/MethodLength
       I18n.with_locale(locale) do
         # when an array has to be inserted with a default value, it needs to

--- a/lib/lit/import.rb
+++ b/lib/lit/import.rb
@@ -142,8 +142,6 @@ module Lit
         Lit::Localization.joins(:locale, :localization_key)
                          .find_by('localization_key = ? and locale = ?', key, locale)
 
-        return unless existing_translation
-
         if @raw
           existing_translation.update(default_value: value)
         else

--- a/lib/lit/import.rb
+++ b/lib/lit/import.rb
@@ -136,19 +136,19 @@ module Lit
         # is the array
         val = value.is_a?(Array) ? [value] : value
         I18n.t(key, default: val)
+      end
 
-        # this indicates that this translation already exists
-        existing_translation =
-        Lit::Localization.joins(:locale, :localization_key)
-                         .find_by('localization_key = ? and locale = ?', key, locale)
+      # this indicates that this translation already exists
+      existing_translation =
+      Lit::Localization.joins(:locale, :localization_key)
+                        .find_by('localization_key = ? and locale = ?', key, locale)
 
-        if @raw
-          existing_translation.update(default_value: value)
-        else
-          existing_translation.update(translated_value: value, is_changed: true)
-          lkey = existing_translation.localization_key
-          lkey.update(is_deleted: false) if lkey.is_deleted
-        end
+      if @raw
+        existing_translation.update(default_value: value)
+      else
+        existing_translation.update(translated_value: value, is_changed: true)
+        lkey = existing_translation.localization_key
+        lkey.update(is_deleted: false) if lkey.is_deleted
       end
     end
 


### PR DESCRIPTION
- Fixing a comment, where `raw = true` is described as default, but `raw = false` is default
- Removing superfluous return statement: the translation is created automatically due to Lits usage of a custom cache and backend during key lookup `I18n.t(key, default: val)`
- Using `switch_locale` only for I18n lookup