### PR TITLE
Fix bug with overwriting of defaults with recent Rails 6.1 compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-### Added
-- Proper CHANGELOG [@pnikrat](https://github.com/pnikrat)
+### Fixed
+- When running Lit on Rails 6.1 defaults could sometimes be overwritten [@pnikrat](https://github.com/pnikrat)
 
 ## [WIP]
 - Efforts to use Vanilla JS and remove jQuery [WIP]
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - When using Cloud translations, support V2 `google-cloud-translate` gem [@pnikrat](https://github.com/pnikrat)
 - Proper Rails 6.1 support. Fixes new Rails translate logic not saving defaults in Lit [@pnikrat](https://github.com/pnikrat)
 - Add screenshots to README [@mlitwiniuk](https://github.com/mlitwiniuk)
+- Proper CHANGELOG [@pnikrat](https://github.com/pnikrat)
 
 ### Changed
 - Lit now uses Ruby 2.7.4 [@pnikrat](https://github.com/pnikrat)

--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -23,6 +23,18 @@ module Lit::FrontendHelper
     def t(key, options = {})
       translate(key, options)
     end
+
+    def missing_translation(key, options)
+      # We try to humanize the key. Rails will do
+      # it anyway in below call to super, but then it will wrap it also in
+      # translation_missing span.
+      # Humanizing key should be last resort
+      if Lit::Services::HumanizeService.should_humanize?(key)
+        return Lit::Services::HumanizeService.humanize_and_cache(key, options)
+      end
+
+      super(key, options)
+    end
   end
   prepend Lit::FrontendHelper::TranslationKeyWrapper
 

--- a/lib/lit/i18n_backend.rb
+++ b/lib/lit/i18n_backend.rb
@@ -28,7 +28,7 @@ module Lit
         @untranslated_key = key if key.present? && options[:default].instance_of?(Object)
 
         if key.nil? && options[:lit_default_copy].present?
-          update_default_localization(locale, content, options)
+          update_default_localization(locale, options)
         end
       end
 
@@ -72,10 +72,12 @@ module Lit
         ::Rails::VERSION::MAJOR >= 7
     end
 
-    def update_default_localization(locale, content, options)
+    def update_default_localization(locale, options)
       parts = I18n.normalize_keys(locale, @untranslated_key, options[:scope], options[:separator])
       key_with_locale = parts.join('.')
-      @cache.update_locale(key_with_locale, content, content.is_a?(Array))
+      content = options[:lit_default_copy]
+      # we do not force array on singular strings packed into Array
+      @cache.update_locale(key_with_locale, content, content.is_a?(Array) && content.length > 1)
     end
 
     def can_dup_default(options = {})

--- a/lib/lit/services/humanize_service.rb
+++ b/lib/lit/services/humanize_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Lit
+  module Services
+    # Checks if should humanize based on config and blacklist.
+    # Performs humanize if required
+    # Caches the value of humanization
+    class HumanizeService
+      def self.should_humanize?(key)
+        Lit.humanize_key && Lit.humanize_key_ignored.match(key).nil?
+      end
+
+      def self.humanize(key)
+        key.to_s.split('.').last.humanize
+      end
+
+      def self.humanize_and_cache(key, options)
+        content = humanize(key)
+        parts = I18n.normalize_keys(
+          options[:locale] || I18n.locale, key, options[:scope], options[:separator]
+        )
+        key_with_locale = parts.join('.')
+        I18n.cache_store[key_with_locale] = content
+        I18n.cache_store[key_with_locale]
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/projects/_form.html.erb
+++ b/test/dummy/app/views/projects/_form.html.erb
@@ -11,6 +11,8 @@
     </div>
   <% end %>
 
+  <div><%= t('some_random.key') %></div>
+  <div><%= t('another_random.key', default: 'Random') %></div>
   <div class="field">
     <%= f.label :name %><br />
     <%= f.text_field :name %>

--- a/test/unit/i18n_backend_test.rb
+++ b/test/unit/i18n_backend_test.rb
@@ -32,6 +32,8 @@ class I18nBackendTest < ActiveSupport::TestCase
   end
 
   test 'auto-humanizes key when Lit.humanize_key=true' do
+    # since Rails 6.1 pure i18n calls should not be humanized
+    skip if I18n.backend.send(:on_rails_6_1_or_higher?)
     Lit.humanize_key = true
     I18n.locale = :en
     test_key = 'this_will_get_humanized'
@@ -65,7 +67,8 @@ class I18nBackendTest < ActiveSupport::TestCase
     loc_key_count = -> { Lit::LocalizationKey.where(localization_key: [test_key, fallback_key]).count }
     assert_equal 0, loc_key_count.call
     assert_equal 'foobar', I18n.t(test_key, default: [fallback_key, 'foobar'])
-    assert_equal 2, loc_key_count.call
+    # We do not create localization key record for fallback keys if value is found
+    assert_equal 1, loc_key_count.call
 
     # on subsequent translation calls, they should not be fetched from DB
     assert_no_database_queries do

--- a/test/unit/lit_behaviour_test.rb
+++ b/test/unit/lit_behaviour_test.rb
@@ -252,6 +252,18 @@ class LitBehaviourTest < ActiveSupport::TestCase
     assert_equal hash_result[:sub_one], 'Left leaf'
   end
 
+  test 'it must not overwrite default with I18n content when calling same key twice ' \
+    'with different interpolations' do
+    assert_difference 'Lit::LocalizationKey.count', 1 do
+      I18n.t('interpolated_key', default: 'Candidate %{name}', name: 'Tester')
+    end
+    assert_no_difference 'Lit::LocalizationKey.count' do
+      result = I18n.t('interpolated_key', default: 'Candidate %{name}', name: 'Famous person')
+      assert_equal result, 'Candidate Famous person'
+    end
+    assert_equal find_localization_for('interpolated_key', :en).default_value, 'Candidate %{name}'
+  end
+
   private
 
   def find_localization_for(key, locale)


### PR DESCRIPTION
We've noticed recently that Lit did not save our defaults in live environments.

It looks like there was a bug with my recent Rails 6.1 compatibility fix.

We should not pass content received from I18n directly as a default value. We should use what we receive from default options instead. 

This has been found and debugged using scenario of two calls to `t` with the same key that has interpolated default value but with different interpolation values. See the attached test case. Without the fix both values in the view would be exactly the same i.e - we passed the already interpolated content to function which updated default value in DB. 