### PR TITLE
Adding defer: true to javascript_include_tag

### DIFF
--- a/app/helpers/lit/frontend_helper.rb
+++ b/app/helpers/lit/frontend_helper.rb
@@ -39,7 +39,7 @@ module Lit::FrontendHelper
   prepend Lit::FrontendHelper::TranslationKeyWrapper
 
   def javascript_lit_tag
-    javascript_include_tag 'lit/lit_frontend'
+    javascript_include_tag 'lit/lit_frontend', defer: true
   end
 
   def stylesheet_lit_tag


### PR DESCRIPTION
I'm adding defer: true to javascript_include_tag so that lit JS works even when we are using the "defer" prop on the main application.js include tag (which is usually importing jQuery). 

I don't see what harms that change could do, but please, let me know if it may break things.